### PR TITLE
fix: don't use relative units in media queries (webkit bug)

### DIFF
--- a/src/components/Browse/Browse.module.css
+++ b/src/components/Browse/Browse.module.css
@@ -12,7 +12,7 @@
   flex: 1;
 }
 
-@media (max-width: 60rem) {
+@media (max-width: 60em) {
   .item {
     flex: 1 0 100%;
   }

--- a/src/components/EventSessionSpeaker/EventSessionSpeaker.module.css
+++ b/src/components/EventSessionSpeaker/EventSessionSpeaker.module.css
@@ -1,4 +1,4 @@
-@media (max-width: 55rem) {
+@media (max-width: 55em) {
   .session-speaker-avatar {
     display: none;
   }
@@ -7,7 +7,7 @@
 .bio {
 }
 
-@media (max-width: 100rem) {
+@media (max-width: 100em) {
   .bio {
     column-count: 1 !important;
   }

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -81,7 +81,7 @@ our global anchor style */
   padding: var(--padding-small);
 }
 
-@media (max-width: 40rem) {
+@media (max-width: 40em) {
   .small-print {
     flex-direction: column;
   }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -108,7 +108,7 @@
   color: var(--color-primary);
 }
 
-@media (max-width: 60rem) {
+@media (max-width: 60em) {
   .nav {
     display: none;
   }
@@ -144,7 +144,7 @@
   padding: 1rem 1.5rem;
 }
 
-@media (max-width: 60rem) {
+@media (max-width: 60em) {
   .search-bar-container {
     display: none;
   }

--- a/src/components/Help/Help.module.css
+++ b/src/components/Help/Help.module.css
@@ -7,7 +7,7 @@
   margin: var(--margin-huge) 0;
 }
 
-@media (max-width: 60rem) {
+@media (max-width: 60em) {
   .container {
     display: grid;
     grid-template-columns: repeat(2, 20rem);
@@ -15,7 +15,7 @@
   }
 }
 
-@media (max-width: 30rem) {
+@media (max-width: 30em) {
   .container {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/components/Hero/Hero.module.css
+++ b/src/components/Hero/Hero.module.css
@@ -21,7 +21,7 @@
   margin: 0 auto var(--margin-large);
 }
 
-@media (max-width: 40rem) {
+@media (max-width: 40em) {
   .hero-title {
     font-size: 5rem;
     line-height: 1.2;

--- a/src/components/PostMetadata/PostMetadata.module.css
+++ b/src/components/PostMetadata/PostMetadata.module.css
@@ -28,7 +28,7 @@
   text-align: right;
 }
 
-@media (max-width: 36rem) {
+@media (max-width: 36em) {
   .metadata-image-container {
     display: none;
   }

--- a/src/components/SearchBar/SearchBar.module.css
+++ b/src/components/SearchBar/SearchBar.module.css
@@ -14,14 +14,14 @@
   width: 100%;
 }
 
-@media (max-width: 60rem) {
+@media (max-width: 60em) {
   .search-bar {
     margin: var(--margin-large) var(--margin-medium);
     padding: 0 var(--padding-medium);
   }
 }
 
-@media (max-width: 40rem) {
+@media (max-width: 40em) {
   .search-bar-input {
     font-size: var(--font-size-large);
     padding: var(--padding-large);

--- a/src/components/TOC/TOC.module.css
+++ b/src/components/TOC/TOC.module.css
@@ -46,7 +46,7 @@
   margin: 1rem;
 }
 
-@media (max-width: 100rem) {
+@media (max-width: 100em) {
   .container {
     height: unset;
     margin: var(--margin-huge) 0;

--- a/src/components/TagCloud/TagCloud.module.css
+++ b/src/components/TagCloud/TagCloud.module.css
@@ -11,7 +11,7 @@
   padding: var(--padding-xsmall) var(--padding-medium);
 }
 
-@media (max-width: 30rem) {
+@media (max-width: 30em) {
   .tags {
     margin: var(--margin-large) 0;
   }

--- a/src/components/VideoCard/VideoCard.module.css
+++ b/src/components/VideoCard/VideoCard.module.css
@@ -3,7 +3,7 @@
   flex: 1;
 }
 
-@media (max-width: 60rem) {
+@media (max-width: 60em) {
   .item {
     flex: 1 0 100%;
   }

--- a/src/elements/Grid/Grid.module.css
+++ b/src/elements/Grid/Grid.module.css
@@ -28,7 +28,7 @@
   );
 }
 
-@media (max-width: 30rem) {
+@media (max-width: 30em) {
   .grid {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
potentially fix webkit issue with `rem` in media query