### PR TITLE
feat: allow image captions

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -200,6 +200,9 @@ module.exports = {
               maxWidth: 800,
               withWebp: true,
               linkImagesToOriginal: false,
+              // change to ['title', 'alt'] if we want to use alt text as fallback caption
+              showCaptions: ['title'],
+              markdownCaptions: true,
             },
           },
           'gatsby-remark-copy-linked-files',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,3 +127,10 @@ div#eventoverlay[data-reach-dialog-content] {
   padding: unset;
   margin: unset;
 }
+
+figcaption.gatsby-resp-image-figcaption {
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 90%;
+  padding: var(--padding-small);
+}


### PR DESCRIPTION
TIL that markdown actually has syntax for image titles:

```md
![alt text](/path/to/image.png "image title")
```

`gatsby-remark-images` can generate captions from these -- would also be possible to use alt text as fallback caption, which is currently disabled (see comment)

fixes: #53