### PR TITLE
feat: allow passing startTime option (in seconds) to VideoCard component

### DIFF
--- a/src/components/VideoCard/VideoCard.js
+++ b/src/components/VideoCard/VideoCard.js
@@ -11,7 +11,15 @@ import Heading from 'elements/Heading/Heading'
 
 import styles from './VideoCard.module.css'
 
-const VideoCard = ({ className, id, image, images, title, subtitle }) => {
+const VideoCard = ({
+  className,
+  id,
+  image,
+  images,
+  title,
+  startTime,
+  subtitle,
+}) => {
   let placeholderImage = null
 
   // The `images` prop holds the injected images in the `images` folder of a post
@@ -24,7 +32,10 @@ const VideoCard = ({ className, id, image, images, title, subtitle }) => {
   }
 
   return (
-    <Lightbox overlay={<Youtube id={id} autoPlay />} className={styles.item}>
+    <Lightbox
+      overlay={<Youtube id={id} startTime={startTime} autoPlay />}
+      className={styles.item}
+    >
       <Card className={clsx(styles.card, className)}>
         <Card.Body className={styles.cardBody}>
           {placeholderImage ? (

--- a/src/components/Youtube/Youtube.js
+++ b/src/components/Youtube/Youtube.js
@@ -9,6 +9,7 @@ const Youtube = ({
   caption,
   id,
   relatedVideos = false,
+  startTime, // in seconds, e.g. 60
   url,
 }) => {
   const aspectRatio = 9 / 16
@@ -44,6 +45,10 @@ const Youtube = ({
 
   if (autoPlay) {
     embedUrl.searchParams.set('autoplay', 1)
+  }
+
+  if (startTime) {
+    embedUrl.searchParams.set('start', startTime)
   }
 
   return (


### PR DESCRIPTION
fixes: #70

example:
```jsx
<VideoCard
  title="Cowboys and Consortia"
  subtitle="Thoughts on DH Infrastructure"
  id="0vkHutf_UxY"
  startTime="120" // start at 2min
  image="images/dh-infrastructure.png"
/>
```