### PR TITLE
feat: use client-side transitions for relative links in docs

### DIFF
--- a/src/common/RelativeOrAbsoluteLink.tsx
+++ b/src/common/RelativeOrAbsoluteLink.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+import type { ComponentPropsWithoutRef } from 'react'
+
+import { isAbsoluteUrl } from '@/utils/isAbsoluteUrl'
+
+/**
+ * Uses client-side transition for relative links, and a regular HTML anchor
+ * element for absolute urls.
+ */
+export function RelativeOrAbsoluteLink(
+  props: ComponentPropsWithoutRef<'a'>,
+): JSX.Element | null {
+  if (props.href == null) return null
+
+  if (isAbsoluteUrl(props.href)) {
+    return <a {...props}>{props.children}</a>
+  }
+
+  return (
+    <Link href={props.href}>
+      <a {...props} rel={undefined} target={undefined}>
+        {props.children}
+      </a>
+    </Link>
+  )
+}

--- a/src/utils/isAbsoluteUrl.ts
+++ b/src/utils/isAbsoluteUrl.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns whether a URL is absolute.
+ */
+export function isAbsoluteUrl(url: string): boolean {
+  try {
+    new URL(url)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/views/docs/Docs.tsx
+++ b/src/views/docs/Docs.tsx
@@ -1,4 +1,5 @@
 import type { Doc as DocData, DocPreview } from '@/cms/api/docs.api'
+import { RelativeOrAbsoluteLink } from '@/common/RelativeOrAbsoluteLink'
 import { ResponsiveImage } from '@/common/ResponsiveImage'
 import { useI18n } from '@/i18n/useI18n'
 import { Mdx as DocsContent } from '@/mdx/Mdx'
@@ -27,7 +28,10 @@ export function Docs(props: DocsProps): JSX.Element {
         </div>
       </header>
       <div className="prose-sm prose max-w-none sm:prose sm:max-w-none">
-        <DocsContent code={docs.code} components={{ Image: ResponsiveImage }} />
+        <DocsContent
+          code={docs.code}
+          components={{ Image: ResponsiveImage, a: RelativeOrAbsoluteLink }}
+        />
       </div>
       <footer>
         {lastUpdatedAt != null ? (


### PR DESCRIPTION
currently, all links in mdx content are rendered with a regular html anchor tag - for relative links in the docs, we probably want to use client-side transitions to avoid full page reloads.