### PR TITLE
build: run prettier --write in pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:coverage": "yarn run test --coverage",
     "test:watch": "yarn run test --watch",
     "typecheck": "tsc --noEmit",
-    "validate": "yarn run format && yarn run lint && yarn run typecheck && yarn test"
+    "validate": "yarn run format:fix && yarn run lint && yarn run typecheck && yarn test"
   },
   "engines": {
     "node": "14.x",


### PR DESCRIPTION
currently, we run prettier to autoformat code and mdx content in a pre-push hook, which means that the push will fail when something is formatted incorrectly. this PR enables prettier to auto-fix incorrect formatting, which will allow the push to succeed anyway - note however that the auto-fixes will not be part of the commit. also note that for users using git in a terminal, `lint-staged` should take care of autoformatting on every commit (i guess this is not running with github desktop??)