### PR TITLE
fix: use url fragments in curriculum overview

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -42,7 +42,7 @@
     "one": "this curriculum",
     "other": "these curricula"
   },
-  "lessonsInCourse": "This curriculum contains",
+  "curriculumOverview": "Curriculum overview",
   "tags": "Topics",
   "tagsPageTitle": "Interested in particular topics?",
   "tagsPageLeadIn": "Browse learning resources based on their topic",

--- a/src/pages/curriculum/[id].page.tsx
+++ b/src/pages/curriculum/[id].page.tsx
@@ -241,15 +241,18 @@ function LessonsList(props: LessonsListProps) {
   if (resources.length === 0) return null
 
   return (
-    <nav aria-label={t('common.lessonsInCourse')} className="w-full space-y-2">
+    <nav
+      aria-label={t('common.curriculumOverview')}
+      className="w-full space-y-2"
+    >
       <h2 className="text-xs font-bold tracking-wide uppercase text-neutral-600">
-        {t('common.lessonsInCourse')}
+        {t('common.curriculumOverview')}
       </h2>
       <ol className="space-y-2">
-        {resources.map((resource) => {
+        {resources.map((resource, index) => {
           return (
             <li key={resource.id}>
-              <Link href={routes.resource({ kind: 'posts', id: resource.id })}>
+              <Link href={{ hash: `resource-${index}` }}>
                 <a className="flex items-center text-sm space-x-1.5 transition hover:text-primary-600 relative focus:outline-none rounded focus-visible:ring focus-visible:ring-primary-600">
                   {resource.shortTitle ?? resource.title}
                 </a>

--- a/src/views/post/Course.tsx
+++ b/src/views/post/Course.tsx
@@ -38,9 +38,13 @@ export function Course(props: CourseProps): JSX.Element {
         <div className="flex flex-col space-y-4">
           <h2 className="text-2xl font-bold">{t('common.resources')}</h2>
           <ol className="space-y-8">
-            {resources.map((resource) => {
+            {resources.map((resource, index) => {
               return (
-                <ResourcePreviewCard key={resource.id} resource={resource} />
+                <ResourcePreviewCard
+                  id={`resource-${index}`}
+                  key={resource.id}
+                  resource={resource}
+                />
               )
             })}
           </ol>

--- a/src/views/post/ResourcePreviewCard.tsx
+++ b/src/views/post/ResourcePreviewCard.tsx
@@ -13,6 +13,7 @@ const MAX_AUTHORS = 3
 
 export interface ResourcePreviewCardProps {
   resource: ResourceListItem
+  id?: string
 }
 
 /**
@@ -29,7 +30,10 @@ export function ResourcePreviewCard(
   const href = routes.resource({ kind, id })
 
   return (
-    <article className="flex flex-col overflow-hidden border shadow-sm rounded-xl hover:shadow-md border-neutral-150">
+    <article
+      id={props.id}
+      className="flex flex-col overflow-hidden border shadow-sm rounded-xl hover:shadow-md border-neutral-150"
+    >
       <div className="flex flex-col px-10 py-10 space-y-5">
         <h2 className="text-2xl font-semibold">
           <Link href={href}>


### PR DESCRIPTION
fixes #120