### PR TITLE
docs: use video component

### DIFF
--- a/content/docs/using-github-directly/index.mdx
+++ b/content/docs/using-github-directly/index.mdx
@@ -242,7 +242,7 @@ To insert a YouTube video, use the following code:
 - the "id" is the part of the url after "v=" and before "&". So, for "https://www.youtube.com/watch?v=SI3u9nu7YEY&t=164s" it is: "SI3u9nu7YEY".
 - "image" allows you to choose a screenshot that will appear until the learner clicks the play button.
 
-There are other options for inserting videos; guidance for these can be found in the [Sample-resource template](https://github.com/DARIAH-ERIC/dariah-campus/tree/main/content/templates)
+There are other options for inserting videos; guidance for these can be found in the [Sample-resource template](https://github.com/DARIAH-ERIC/dariah-campus/blob/main/content/templates/resource/index.mdx?plain=1).
 
 Any video published on the DARIAH-Campus YouTube Channel is covered by a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0). We ask that any externally-hosted videos that you produce as part of your materials are also licenced for reuse.
 

--- a/content/templates/pathfinder/index.mdx
+++ b/content/templates/pathfinder/index.mdx
@@ -148,17 +148,30 @@ The "id" is the part of the url after the equals sign for a YouTube video. So, f
 
 An alternative is to directly embed the video from YouTube, which you do in the following way:
 
-<Youtube id="OqYJNUmhJzw" caption="Laurent Romary (Former DARIAH Director)" />
+<Video id="OqYJNUmhJzw" caption="Laurent Romary (Former DARIAH Director)" />
 
 If you are including multiple videos, you might choose to arrange them in a grid formation. You can do this in the following way:
 
 <Grid>
 
-<Youtube id="OqYJNUmhJzw" caption="Laurent Romary (Former DARIAH Director)" />
-<Youtube id="iwz0uhEhtg4" caption="Jennifer Edmond (DARIAH Director)" />
-<Youtube id="soL0itkLYpk" caption="Frank Fischer (DARIAH Director)" />
+<Video id="OqYJNUmhJzw" caption="Laurent Romary (Former DARIAH Director)" />
+<Video id="iwz0uhEhtg4" caption="Jennifer Edmond (DARIAH Director)" />
+<Video id="soL0itkLYpk" caption="Frank Fischer (DARIAH Director)" />
 
 </Grid>
+
+To include videos hosted on platforms other than YouTube, you can specify a `provider`. Currently supported providers are: `youtube`, `vimeo` and `nakala`.
+
+<Video
+  id="10.34847/nkl.f734kiqd/4701b123138c721007562e3caacecd6a208d329f"
+  provider="nakala"
+  caption="Nakala example"
+/>
+<VideoCard
+  id="10.34847/nkl.f734kiqd/4701b123138c721007562e3caacecd6a208d329f"
+  provider="nakala"
+  title="Nakala example"
+/>
 
 #### Heading level four
 

--- a/content/templates/resource/index.mdx
+++ b/content/templates/resource/index.mdx
@@ -148,17 +148,30 @@ The "id" is the part of the url after the equals sign for a YouTube video. So, f
 
 An alternative is to directly embed the video from YouTube, which you do in the following way:
 
-<Youtube id="OqYJNUmhJzw" caption="Laurent Romary (Former DARIAH Director)" />
+<Video id="OqYJNUmhJzw" caption="Laurent Romary (Former DARIAH Director)" />
 
 If you are including multiple videos, you might choose to arrange them in a grid formation. You can do this in the following way:
 
 <Grid>
 
-<Youtube id="OqYJNUmhJzw" caption="Laurent Romary (Former DARIAH Director)" />
-<Youtube id="iwz0uhEhtg4" caption="Jennifer Edmond (DARIAH Director)" />
-<Youtube id="soL0itkLYpk" caption="Frank Fischer (DARIAH Director)" />
+<Video id="OqYJNUmhJzw" caption="Laurent Romary (Former DARIAH Director)" />
+<Video id="iwz0uhEhtg4" caption="Jennifer Edmond (DARIAH Director)" />
+<Video id="soL0itkLYpk" caption="Frank Fischer (DARIAH Director)" />
 
 </Grid>
+
+To include videos hosted on platforms other than YouTube, you can specify a `provider`. Currently supported providers are: `youtube`, `vimeo` and `nakala`.
+
+<Video
+  id="10.34847/nkl.f734kiqd/4701b123138c721007562e3caacecd6a208d329f"
+  provider="nakala"
+  caption="Nakala example"
+/>
+<VideoCard
+  id="10.34847/nkl.f734kiqd/4701b123138c721007562e3caacecd6a208d329f"
+  provider="nakala"
+  title="Nakala example"
+/>
 
 #### Heading level four
 


### PR DESCRIPTION
this pr uses the `Video` component in the docs instead of the deprecated `YouTube` component, and shows how to specify a `provider` other than YouTube.

also fixes a link to the example template.

closes #106