### PR TITLE
fix: update broken vocabs link

### DIFF
--- a/content/posts/controlled-vocabularies-and-skos/index.mdx
+++ b/content/posts/controlled-vocabularies-and-skos/index.mdx
@@ -618,7 +618,7 @@ _Category: General_
 
 _Category: Meta-thesauri_
 
-- [Backbone Thesaurus](https://vocabs.acdh.oeaw.ac.at/backbone_thesaurus/en/)
+- [Backbone Thesaurus](https://vocabs.acdh.oeaw.ac.at/bbt/en/)
 
 _Category: Resource type_
 


### PR DESCRIPTION
this pr fixes a broken link in the "Controlled Vocabularies and SKOS" resource.