### PR TITLE
feat: allow publishing draft resources (hidden on main branch)

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -26,6 +26,7 @@
   "search": "Search...",
   "noResultsFound": "Nothing found",
   "readMore": "Read more",
+  "comingSoon": "Coming soon",
   "publishDate": "Publish date",
   "lastUpdated": "Last updated",
   "timeToRead": "Time to read",

--- a/src/cms/api/posts.api.ts
+++ b/src/cms/api/posts.api.ts
@@ -72,6 +72,7 @@ export interface PostFrontmatter {
   }
   licence: LicenceId['id']
   toc?: boolean
+  draft?: boolean
 }
 
 export interface PostMetadata

--- a/src/cms/collections/posts.collection.ts
+++ b/src/cms/collections/posts.collection.ts
@@ -259,5 +259,13 @@ export const collection: CmsCollection = {
       widget: 'boolean',
       default: false,
     },
+    {
+      name: 'draft',
+      label: 'Hide this resource',
+      hint: '',
+      required: false,
+      widget: 'boolean',
+      default: false,
+    },
   ],
 }

--- a/src/cms/utils/isResourceHidden.ts
+++ b/src/cms/utils/isResourceHidden.ts
@@ -1,0 +1,7 @@
+const isMainBranch = process.env['NEXT_PUBLIC_GIT_BRANCH'] === 'main'
+
+export function isResourceHidden(draft: boolean | undefined): boolean {
+  if (draft === true && isMainBranch) return true
+
+  return false
+}

--- a/src/pages/resource/[kind]/[id].page.tsx
+++ b/src/pages/resource/[kind]/[id].page.tsx
@@ -22,6 +22,7 @@ import { getCoursePreviewsByResourceId } from '@/cms/queries/courses.queries'
 import { getPostPreviewsByTagId } from '@/cms/queries/posts.queries'
 import { getFullName } from '@/cms/utils/getFullName'
 import { getLastUpdatedTimestamp } from '@/cms/utils/getLastUpdatedTimestamp'
+import { isResourceHidden } from '@/cms/utils/isResourceHidden'
 import { pickRandom } from '@/cms/utils/pickRandom'
 import { Icon } from '@/common/Icon'
 import { PageContent } from '@/common/PageContent'
@@ -131,6 +132,10 @@ export async function getStaticProps(
   }
 
   const resource = await getPostById(id, locale)
+
+  if (isResourceHidden(resource.data.metadata.draft)) {
+    return { notFound: true }
+  }
 
   const resourcesWithSharedTags = (
     await Promise.all(

--- a/src/pages/resources/page/[page].page.tsx
+++ b/src/pages/resources/page/[page].page.tsx
@@ -13,6 +13,7 @@ import { getPostPreviews, getPostIds } from '@/cms/api/posts.api'
 import { getTags } from '@/cms/api/tags.api'
 import { getEventPreviewsByTagId } from '@/cms/queries/events.queries'
 import { getPostPreviewsByTagId } from '@/cms/queries/posts.queries'
+import { isResourceHidden } from '@/cms/utils/isResourceHidden'
 import type { Page } from '@/cms/utils/paginate'
 import { getPageRange, paginate } from '@/cms/utils/paginate'
 import { Accordion } from '@/common/Accordion'
@@ -94,7 +95,9 @@ export async function getStaticProps(
   const postPreviews = await getPostPreviews(locale)
   const eventPreviews = await getEventPreviews(locale)
   const resourcePreviews = getResourceListData([
-    ...postPreviews,
+    ...postPreviews.filter((preview) => {
+      return !isResourceHidden(preview.draft)
+    }),
     ...eventPreviews,
   ])
   const sortedResources: Array<ResourceListItem> = resourcePreviews.sort(

--- a/src/views/post/ResourcePreviewCard.tsx
+++ b/src/views/post/ResourcePreviewCard.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 
 import { Svg as DefaultAvatar } from '@/assets/icons/user.svg'
 import { getFullName } from '@/cms/utils/getFullName'
+import { isResourceHidden } from '@/cms/utils/isResourceHidden'
 import { Icon } from '@/common/Icon'
 import { useI18n } from '@/i18n/useI18n'
 import { routes } from '@/navigation/routes.config'
@@ -23,11 +24,12 @@ export function ResourcePreviewCard(
   props: ResourcePreviewCardProps,
 ): JSX.Element {
   const { resource } = props
-  const { id, kind, title, authors, abstract, type } = resource
+  const { id, kind, title, authors, abstract, type, draft } = resource
 
   const { t } = useI18n()
 
   const href = routes.resource({ kind, id })
+  const isHidden = isResourceHidden(draft)
 
   return (
     <article
@@ -36,8 +38,8 @@ export function ResourcePreviewCard(
     >
       <div className="flex flex-col px-10 py-10 space-y-5">
         <h2 className="text-2xl font-semibold">
-          <Link href={href}>
-            <a className="block transition rounded hover:text-primary-600 focus:outline-none focus-visible:ring focus-visible:ring-primary-600">
+          {isHidden ? (
+            <div>
               <span className="inline-flex mr-2 text-primary-600">
                 <ContentTypeIcon
                   type={type.id}
@@ -45,8 +47,20 @@ export function ResourcePreviewCard(
                 />
               </span>
               <span>{title}</span>
-            </a>
-          </Link>
+            </div>
+          ) : (
+            <Link href={href}>
+              <a className="block transition rounded hover:text-primary-600 focus:outline-none focus-visible:ring focus-visible:ring-primary-600">
+                <span className="inline-flex mr-2 text-primary-600">
+                  <ContentTypeIcon
+                    type={type.id}
+                    className="flex-shrink-0 w-5 h-5"
+                  />
+                </span>
+                <span>{title}</span>
+              </a>
+            </Link>
+          )}
         </h2>
         <div className="leading-7 text-neutral-500">{abstract}</div>
       </div>
@@ -84,11 +98,15 @@ export function ResourcePreviewCard(
             </div>
           ) : null}
         </dl>
-        <Link href={href}>
-          <a tabIndex={-1} className="transition hover:text-primary-600">
-            {t('common.readMore')} &rarr;
-          </a>
-        </Link>
+        {isHidden ? (
+          <span className="text-neutral-500">{t('common.comingSoon')}</span>
+        ) : (
+          <Link href={href}>
+            <a tabIndex={-1} className="transition hover:text-primary-600">
+              {t('common.readMore')} &rarr;
+            </a>
+          </Link>
+        )}
       </footer>
     </article>
   )

--- a/src/views/post/getResourceListData.ts
+++ b/src/views/post/getResourceListData.ts
@@ -8,6 +8,7 @@ export interface ResourceListItem
   extends Pick<ResourcePreview, 'id' | 'kind' | 'title' | 'date' | 'abstract'> {
   type: Pick<ResourcePreview['type'], 'id'>
   authors: Array<AuthorListItem>
+  draft?: boolean
 }
 
 /**
@@ -21,6 +22,7 @@ export function getResourceListData(
       id: resource.id,
       kind: resource.kind,
       type: resource.type,
+      draft: resource.kind === 'posts' && resource.draft === true,
       title: resource.shortTitle ?? resource.title,
       date: resource.date,
       abstract: resource.abstract,


### PR DESCRIPTION
this allows publishing a post resource with a `draft` flag. this will hide the resource only on the main branch (completely hidden in resource list view, visible but without link in the curriculum view)