### PR TITLE
feat: allow linking resources from richtext widget

### DIFF
--- a/src/cms/collections/courses.collection.ts
+++ b/src/cms/collections/courses.collection.ts
@@ -170,6 +170,7 @@ export const collection: CmsCollection = {
         'Download',
         'Video',
         'SideNote',
+        'ResourceLink',
       ],
     },
     // {

--- a/src/cms/collections/posts.collection.ts
+++ b/src/cms/collections/posts.collection.ts
@@ -156,6 +156,7 @@ export const collection: CmsCollection = {
         'SideNote',
         'ExternalResource',
         'Quiz',
+        'ResourceLink',
       ],
     },
     {

--- a/src/cms/components/ResourceLink.tsx
+++ b/src/cms/components/ResourceLink.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export interface ResourceLinkProps {
+  type: 'posts'
+  id: string
+  label: string
+}
+
+export function ResourceLink(props: ResourceLinkProps): JSX.Element {
+  return (
+    <Link href={{ pathname: `/resource/${props.type}/${props.id}` }}>
+      <a>{props.label}</a>
+    </Link>
+  )
+}

--- a/src/cms/widgets/ResourceLink.tsx
+++ b/src/cms/widgets/ResourceLink.tsx
@@ -1,0 +1,49 @@
+import type { EditorComponentOptions } from 'netlify-cms-core'
+
+/**
+ * Netlify CMS richtext editor widget for linking other resources.
+ */
+export const resourceLinkWidget: EditorComponentOptions = {
+  id: 'ResourceLink',
+  label: 'ResourceLink',
+  fields: [
+    {
+      name: 'id',
+      label: 'Resource',
+      widget: 'relation',
+      /* @ts-expect-error Missing on upstream type. */
+      collection: 'posts',
+      value_field: '{{slug}}',
+      search_fields: ['title'],
+      display_fields: ['title'],
+    },
+    { name: 'label', label: 'Label', widget: 'string' },
+  ],
+  pattern: /^<ResourceLink(.*?)\/>/,
+  fromBlock(match) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const attrs = match[1]!
+
+    const id = /id="([^"]*)"/.exec(attrs)
+    const label = /label="([^"]*)"/.exec(attrs)
+
+    return {
+      id: id ? id[1] + '/index' : undefined,
+      label: label ? label[1] : undefined,
+    }
+  },
+  toBlock(data) {
+    const id = data.id?.slice(0, -6 /* '/index' */)
+    const label = data.label
+
+    if (id == null || label == null) return ''
+
+    return `<ResourceLink type="posts" id="${id}" label="${label}" />`
+  },
+  /**
+   * This is only used in `getWidgetFor` (which we don't use).
+   */
+  toPreview() {
+    return `ResourceLink`
+  },
+}

--- a/src/mdx/components.ts
+++ b/src/mdx/components.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from 'react'
 
 import { Download } from '@/cms/components/Download'
 import { Grid } from '@/cms/components/Grid'
+import { ResourceLink } from '@/cms/components/ResourceLink'
 import { SideNote } from '@/cms/components/SideNote'
 import { Video } from '@/cms/components/Video'
 
@@ -57,6 +58,7 @@ const legacyComponents: MdxComponentMap = {
 export const components: MdxComponentMap = {
   ...legacyComponents,
   Download,
+  ResourceLink,
   Grid,
   SideNote,
   Video,

--- a/src/pages/admin.page.tsx
+++ b/src/pages/admin.page.tsx
@@ -31,6 +31,7 @@ const Cms = dynamic(
     const { CoursePreview } = await import('@/cms/previews/CoursePreview')
     const { EventPreview } = await import('@/cms/previews/EventPreview')
     const { DocPreview } = await import('@/cms/previews/DocPreview')
+
     const { downloadWidget } = await import('@/cms/widgets/Download')
     const { sideNoteEditorWidget } = await import('@/cms/widgets/SideNote')
     const { videoEditorWidget } = await import('@/cms/widgets/Video')
@@ -48,6 +49,8 @@ const Cms = dynamic(
     const { eventSessionLinkEditorWidget } = await import(
       '@/cms/widgets/EventSessionLink'
     )
+    const { resourceLinkWidget } = await import('@/cms/widgets/ResourceLink')
+
     const { default: withResourceLinks } = await import(
       '@stefanprobst/remark-resource-links'
     )
@@ -107,6 +110,7 @@ const Cms = dynamic(
     Cms.registerEditorComponent(eventSessionSpeakersEditorWidget)
     Cms.registerEditorComponent(eventSessionDownloadEditorWidget)
     Cms.registerEditorComponent(eventSessionLinkEditorWidget)
+    Cms.registerEditorComponent(resourceLinkWidget)
 
     /**
      * Register plugins to the richtext editor widget to (i) avoid saving


### PR DESCRIPTION
this adds a richtext editor widget to insert links to other resources.

todo: figure out how to make it work inline vs block-level (text before and after will always be wrapped in `<p>`) - cf. https://github.com/netlify/netlify-cms/blob/master/packages/netlify-cms-widget-markdown/src/MarkdownControl/renderers.js#L345-L350, also [this issue](https://github.com/netlify/netlify-cms/issues/5065).