### PR TITLE
fix: copy event synthesis to static assets folder

### DIFF
--- a/src/cms/api/events.api.ts
+++ b/src/cms/api/events.api.ts
@@ -148,6 +148,13 @@ export async function getEventById(id: ID, locale: Locale): Promise<Event> {
   const [file, previewMetadata] = await readFileAndGetEventMetadata(id, locale)
   const code = String(await compileMdx(file))
 
+  if (previewMetadata.synthesis != null) {
+    const paths = copyAsset(previewMetadata.synthesis, file.path, 'asset')
+    if (paths != null) {
+      previewMetadata.synthesis = paths.publicPath
+    }
+  }
+
   const metadata = {
     ...previewMetadata,
     sessions: await Promise.all(

--- a/src/cms/components/Download.tsx
+++ b/src/cms/components/Download.tsx
@@ -3,16 +3,17 @@ import type { UrlString } from '@/utils/ts/aliases'
 export interface DownloadProps {
   url: UrlString
   title: string
+  fileName?: string
 }
 
 /**
  * Download link.
  */
 export function Download(props: DownloadProps): JSX.Element {
-  const { url, title } = props
+  const { url, title, fileName } = props
 
   return (
-    <a href={url} download>
+    <a href={url} download={fileName ?? true}>
       {title}
     </a>
   )

--- a/src/mdx/plugins/rehype-download-links.ts
+++ b/src/mdx/plugins/rehype-download-links.ts
@@ -1,3 +1,5 @@
+import { basename } from 'path'
+
 import type * as Hast from 'hast'
 import type { MDXJsxTextElement, MDXJsxFlowElement } from 'hast-util-to-estree'
 import type { Transformer } from 'unified'
@@ -24,7 +26,7 @@ export default function attacher(): Transformer {
 
       node.properties = node.properties ?? {}
       node.properties.href = publicPath
-      node.properties.download = true
+      node.properties.download = file.path != null ? basename(file.path) : true
     }
 
     visit(tree, ['mdxJsxTextElement', 'mdxJsxFlowElement'], onMdxJsxElement)
@@ -45,6 +47,20 @@ export default function attacher(): Transformer {
 
       if (urlAttribute != null) {
         urlAttribute.value = publicPath
+      }
+
+      const fileNameAttribute = node.attributes.find(
+        /** Ignore `MDXJsxExpressionAttribute`. */
+        (attribute) => {
+          return 'name' in attribute && attribute.name === 'fileName'
+        },
+      )
+      if (fileNameAttribute == null && file.path != null) {
+        node.attributes.push({
+          type: 'mdxJsxAttribute',
+          name: 'fileName',
+          value: basename(file.path),
+        })
       }
     }
   }


### PR DESCRIPTION
fixes #617

copy event synthesis to static assets folder