### PR TITLE
fix: display all available tags on page

### DIFF
--- a/src/pages/tags/page/[page].page.tsx
+++ b/src/pages/tags/page/[page].page.tsx
@@ -27,7 +27,7 @@ import { type TagListItem } from "@/views/post/getTagListData";
 import { TagsList } from "@/views/post/TagsList";
 import HeroImage from "~/public/assets/images/study.svg";
 
-const pageSize = 50;
+const pageSize = 500;
 
 type TagWithPostCount = TagListItem & { posts: number };
 


### PR DESCRIPTION
closes #696 