### PR TITLE
feat: add handle ids to resources [skip ci]

### DIFF
--- a/.github/workflows/generate-handle-ids.yml
+++ b/.github/workflows/generate-handle-ids.yml
@@ -49,7 +49,7 @@ jobs:
           HANDLE_PROVIDER: ${{ vars.HANDLE_PROVIDER }}
           HANDLE_PREFIX: ${{ vars.HANDLE_PREFIX }}
           HANDLE_RESOLVER: ${{ vars.HANDLE_RESOLVER }}
-          NUXT_PUBLIC_APP_BASE_URL: ${{ vars.NUXT_PUBLIC_APP_BASE_URL }}
+          NEXT_PUBLIC_APP_BASE_URL: ${{ vars.NEXT_PUBLIC_APP_BASE_URL }}
         run: |
           for file in ${{ steps.get-changed-files.outputs.files }}
           do

--- a/.github/workflows/generate-handle-ids.yml
+++ b/.github/workflows/generate-handle-ids.yml
@@ -58,8 +58,8 @@ jobs:
           done
           if [ -n "$(git diff --staged)" ];
           then
-            git config user.name "${{ vars.GITHUB_USERNAME }}"
-            git config user.email "${{ vars.GITHUB_EMAIL }}"
+            git config user.name "${{ vars.GIT_USERNAME }}"
+            git config user.email "${{ vars.GIT_EMAIL }}"
             git commit -m "content: add handle ids"
             git push origin
           fi

--- a/.github/workflows/generate-handle-ids.yml
+++ b/.github/workflows/generate-handle-ids.yml
@@ -1,0 +1,65 @@
+name: Generate handle ids
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - content/**/*.mdx
+
+jobs:
+  generate-doi:
+    name: Generate handle ids
+    runs-on: ubuntu-latest
+    if: github.event.forced == false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Use node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Get changed files
+        id: get-changed-files
+        run: |
+          files=$(git diff --diff-filter=AMR --name-only ${{ github.event.before }} ${{ github.event.after }} -- content/**/*.mdx | xargs)
+          echo files="$files" >> $GITHUB_OUTPUT
+
+      - name: Generate handle ids
+        if: steps.get-changed-files.outputs.files
+        env:
+          HANDLE_USERNAME: ${{ secrets.HANDLE_USERNAME }}
+          HANDLE_PASSWORD: ${{ secrets.HANDLE_PASSWORD }}
+          HANDLE_PROVIDER: ${{ vars.HANDLE_PROVIDER }}
+          HANDLE_PREFIX: ${{ vars.HANDLE_PREFIX }}
+          HANDLE_RESOLVER: ${{ vars.HANDLE_RESOLVER }}
+          NUXT_PUBLIC_APP_BASE_URL: ${{ vars.NUXT_PUBLIC_APP_BASE_URL }}
+        run: |
+          for file in ${{ steps.get-changed-files.outputs.files }}
+          do
+            node ./scripts/generate-handle-ids.mjs $file
+            git add $file
+          done
+          if [ -n "$(git diff --staged)" ];
+          then
+            git config user.name "${{ vars.GITHUB_USERNAME }}"
+            git config user.email "${{ vars.GITHUB_EMAIL }}"
+            git commit -m "content: add handle ids"
+            git push origin
+          fi

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"validate": "run-s format:check lint:check types:check test"
 	},
 	"dependencies": {
+		"@acdh-oeaw/lib": "^0.1.6",
 		"@codemirror/lang-xml": "^6.0.2",
 		"@codemirror/view": "^6.13.2",
 		"@react-aria/accordion": "^3.0.0-alpha.24",
@@ -76,11 +77,13 @@
 		"shiki": "^0.14.2",
 		"strip-indent": "^4.0.0",
 		"strip-markdown": "^5.0.1",
+		"to-vfile": "^7.2.4",
 		"unified": "^10.1.2",
 		"unist-util-visit": "^4.1.2",
 		"vfile": "^5.3.7",
 		"vfile-matter": "^4.0.1",
-		"yaml": "^2.3.1"
+		"yaml": "^2.3.1",
+		"zod": "^3.22.4"
 	},
 	"devDependencies": {
 		"@acdh-oeaw/commitlint-config": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@acdh-oeaw/lib':
+    specifier: ^0.1.6
+    version: 0.1.6
   '@codemirror/lang-xml':
     specifier: ^6.0.2
     version: 6.0.2(@codemirror/view@6.13.2)
@@ -119,6 +122,9 @@ dependencies:
   strip-markdown:
     specifier: ^5.0.1
     version: 5.0.1
+  to-vfile:
+    specifier: ^7.2.4
+    version: 7.2.4
   unified:
     specifier: ^10.1.2
     version: 10.1.2
@@ -134,6 +140,9 @@ dependencies:
   yaml:
     specifier: ^2.3.1
     version: 2.3.1
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@acdh-oeaw/commitlint-config':
@@ -335,6 +344,11 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
     dev: true
+
+  /@acdh-oeaw/lib@0.1.6:
+    resolution: {integrity: sha512-hNWN4BLrKjEKENlh8Mqu48PrQyj9ZOm43/9z8doHdIqYEhjrk59ak3NVpJ0Ico6fQ3YTsX/K9Cjd7ha3bjEcCA==}
+    engines: {node: '>=18', pnpm: '>=8'}
+    dev: false
 
   /@acdh-oeaw/prettier-config@1.0.0(prettier@2.8.8):
     resolution: {integrity: sha512-/YZqzkiUVexvnhPgic4G2aSfrai8hOEA7YbPkasQNCS6p9TgtfjlK4lbhqVx/EGu5bhUc8mrbHpkt973n7WQBw==}
@@ -4913,7 +4927,7 @@ packages:
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       get-intrinsic: 1.2.1
 
   /callsites@3.1.0:
@@ -6637,7 +6651,7 @@ packages:
   /get-intrinsic@1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       has: 1.0.3
       has-proto: 1.0.1
       has-symbols: 1.0.3
@@ -7964,7 +7978,7 @@ packages:
       jest-pnp-resolver: 1.2.3(jest-resolve@29.5.0)
       jest-util: 29.5.0
       jest-validate: 29.5.0
-      resolve: 1.22.2
+      resolve: 1.22.8
       resolve.exports: 2.0.2
       slash: 3.0.0
     dev: true
@@ -8054,7 +8068,7 @@ packages:
       jest-util: 29.5.0
       natural-compare: 1.4.0
       pretty-format: 29.5.0
-      semver: 7.5.1
+      semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10350,7 +10364,7 @@ packages:
     resolution: {integrity: sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.4
 
   /node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
@@ -10384,7 +10398,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.2
+      resolve: 1.22.8
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
@@ -13097,7 +13111,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -14017,7 +14030,6 @@ packages:
     dependencies:
       is-buffer: 2.0.5
       vfile: 5.3.7
-    dev: true
 
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -15143,6 +15155,10 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
 
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}

--- a/scripts/generate-handle-ids.mjs
+++ b/scripts/generate-handle-ids.mjs
@@ -52,7 +52,7 @@ const configSchema = z.object({
 
 const config = configSchema.parse({
 	resource: {
-		baseUrl: process.env.NUXT_PUBLIC_APP_BASE_URL,
+		baseUrl: process.env.NEXT_PUBLIC_APP_BASE_URL,
 		filePath: process.argv.at(2),
 	},
 	handle: {

--- a/scripts/generate-handle-ids.mjs
+++ b/scripts/generate-handle-ids.mjs
@@ -1,0 +1,137 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { createUrl, log, request } from "@acdh-oeaw/lib";
+import { readSync } from "to-vfile";
+import { matter } from "vfile-matter";
+import YAML from "yaml";
+import { z } from "zod";
+
+const configSchema = z.object({
+	resource: z
+		.object({
+			filePath: z.string(),
+			baseUrl: z.string().url(),
+		})
+		.transform((value) => {
+			const segments = value.filePath.split("/");
+			const resourceType = segments.at(1);
+			const resourceId = segments.at(2);
+
+			if (resourceId == null) return z.NEVER;
+
+			switch (resourceType) {
+				case "courses": {
+					const pathname = ["curriculum", resourceId].join("/");
+					return { ...value, pathname };
+				}
+
+				case "events": {
+					const pathname = ["resource", "events", , resourceId].join("/");
+					return { ...value, pathname };
+				}
+
+				case "posts": {
+					const pathname = ["resource", "posts", , resourceId].join("/");
+					return { ...value, pathname };
+				}
+
+				default: {
+					return z.NEVER;
+				}
+			}
+		}),
+	handle: z.object({
+		username: z.string(),
+		password: z.string(),
+		provider: z.string().url(),
+		prefix: z.string(),
+		resolver: z.string().url(),
+	}),
+});
+
+const config = configSchema.parse({
+	resource: {
+		baseUrl: process.env.NUXT_PUBLIC_APP_BASE_URL,
+		filePath: process.argv.at(2),
+	},
+	handle: {
+		username: process.env.HANDLE_USERNAME,
+		password: process.env.HANDLE_PASSWORD,
+		provider: process.env.HANDLE_PROVIDER,
+		prefix: process.env.HANDLE_PREFIX,
+		resolver: process.env.HANDLE_RESOLVER,
+	},
+});
+
+async function run() {
+	const absoluteFilePath = join(process.cwd(), config.resource.filePath);
+
+	const vfile = readSync(absoluteFilePath, { encoding: "utf-8" });
+	matter(vfile, { strip: true });
+
+	const metadata = /** @type {any} */ (vfile.data.matter);
+
+	if ("handle" in metadata) {
+		return Promise.resolve(false);
+	}
+
+	const resourceUrl = createUrl({
+		baseUrl: config.resource.baseUrl,
+		pathname: config.resource.pathname,
+	});
+
+	const { id, handle } = await createHandle(resourceUrl);
+
+	const fileContent = [
+		"---\n",
+		YAML.stringify({ ...metadata, handle }),
+		"---\n",
+		String(vfile),
+	].join("");
+
+	await writeFileSync(absoluteFilePath, fileContent, { encoding: "utf-8" });
+
+	return Promise.resolve(true);
+}
+
+async function createHandle(resourceUrl) {
+	const url = createUrl({
+		baseUrl: config.handle.provider,
+		pathname: config.handle.prefix,
+	});
+
+	const body = JSON.stringify([{ type: "URL", parsed_data: String(resourceUrl) }]);
+
+	const headers = {
+		authorization:
+			"Bearer " +
+			Buffer.from(`${config.handle.username}:${config.handle.password}`).toString("base64"),
+	};
+
+	const response = /** @type {any} */ (
+		await request(url, {
+			method: "post",
+			headers,
+			body,
+			responseType: "json",
+		})
+	);
+
+	const id = response["epic-pid"];
+	const handle = createUrl({ baseUrl: config.handle.resolver, pathname: id });
+
+	return { id, handle };
+}
+
+run()
+	.then((isGenerated) => {
+		if (isGenerated) {
+			log.success(`Generated handle id for ${config.resource.filePath}.`);
+		} else {
+			log.info(`Handle id already present in ${config.resource.filePath}.`);
+		}
+	})
+	.catch((error) => {
+		log.error(`Failed to generate handle id for ${config.resource.filePath}.\n`, error);
+	});


### PR DESCRIPTION
this adds a github action to generate handle ids for resources, events, and curricula (if it does not find a pre-existing `handle` field in the markdown frontmatter).

the action run on every push to the main branch (e.g. when a pull request is merged), which includes changes to `.mdx` files in the `content` folder.

requires setting the following [github secrets](https://github.com/DARIAH-ERIC/dariah-campus/settings/secrets/actions):
- HANDLE_USERNAME
- HANDLE_PASSWORD

requires setting the following [github variables](https://github.com/DARIAH-ERIC/dariah-campus/settings/variables/actions):
- HANDLE_PROVIDER (e.g. "http://pid.gwdg.de/handles/")
- HANDLE_PREFIX (e.g. "21.11115")
- HANDLE_RESOLVER (e.g. "https://hdl.handle.net/")
- GITHUB_USERNAME and GITHUB_EMAIL (these will be used when creating a new git commit with the updated frontmatter)

TODO:
- [ ] figure out what to use for handle provider and prefix. for now, this is preconfigured with the acdh-ch settings

FUTURE (perf):
- use github's rest api (via octokit or the github cli) to avoid having to set `fetch-depth: 0`