### PR TITLE
feat: add language tag on preview cards

### DIFF
--- a/src/views/post/LanguageTag.tsx
+++ b/src/views/post/LanguageTag.tsx
@@ -1,0 +1,13 @@
+interface LanguageTagProps {
+	lang: string;
+}
+
+export function LanguageTag(props: LanguageTagProps): JSX.Element {
+	const { lang } = props;
+
+	return (
+		<div className="text-xs font-medium bg-primary-600 text-white px-2 py-1 rounded">
+			{lang.toUpperCase()}
+		</div>
+	);
+}

--- a/src/views/post/ResourcePreviewCard.tsx
+++ b/src/views/post/ResourcePreviewCard.tsx
@@ -9,6 +9,7 @@ import { useI18n } from "@/i18n/useI18n";
 import { routes } from "@/navigation/routes.config";
 import { ContentTypeIcon } from "@/views/post/ContentTypeIcon";
 import { type ResourceListItem } from "@/views/post/getResourceListData";
+import { LanguageTag } from "@/views/post/LanguageTag";
 
 const MAX_AUTHORS = 3;
 
@@ -22,7 +23,7 @@ export interface ResourcePreviewCardProps {
  */
 export function ResourcePreviewCard(props: ResourcePreviewCardProps): JSX.Element {
 	const { resource } = props;
-	const { id, kind, title, authors, abstract, type, draft } = resource;
+	const { id, kind, title, authors, abstract, type, draft, lang } = resource;
 
 	const { t } = useI18n();
 
@@ -55,7 +56,10 @@ export function ResourcePreviewCard(props: ResourcePreviewCardProps): JSX.Elemen
 						</Link>
 					)}
 				</h2>
-				<div className="leading-7 text-neutral-500">{abstract}</div>
+				<div className="flex">
+					<LanguageTag lang={lang} />
+				</div>
+				<div className="leading-7 text-neutral-500">{abstract}dLanguageTag</div>
 			</div>
 			<footer className="flex items-center justify-between h-20 px-10 py-5 bg-neutral-100">
 				<dl>

--- a/src/views/post/getResourceListData.ts
+++ b/src/views/post/getResourceListData.ts
@@ -5,7 +5,7 @@ type AuthorListItem = Pick<
 	"avatar" | "firstName" | "id" | "lastName"
 >;
 export interface ResourceListItem
-	extends Pick<ResourcePreview, "abstract" | "date" | "id" | "kind" | "title"> {
+	extends Pick<ResourcePreview, "abstract" | "date" | "id" | "kind" | "lang" | "title"> {
 	type: Pick<ResourcePreview["type"], "id">;
 	authors: Array<AuthorListItem>;
 	draft?: boolean;
@@ -23,6 +23,7 @@ export function getResourceListData(resources: Array<ResourcePreview>): Array<Re
 			draft: resource.kind === "posts" && resource.draft === true,
 			title: resource.shortTitle ?? resource.title,
 			date: resource.date,
+			lang: resource.lang,
 			abstract: resource.abstract,
 			authors: resource.authors.map((author) => {
 				const authorListItem: AuthorListItem = {


### PR DESCRIPTION
this adds a visual indicator about the resource language to the preview cards.

this was a feature request from some time ago - needs discussion where exactly this should go.