### PR TITLE
feat: allow linking to resource translations

### DIFF
--- a/src/cms/collections/posts.collection.ts
+++ b/src/cms/collections/posts.collection.ts
@@ -268,5 +268,17 @@ export const collection: CmsCollection = {
 			widget: "boolean",
 			default: false,
 		},
+		{
+			name: "translations",
+			label: "Translations",
+			hint: "",
+			required: false,
+			widget: "relation",
+			collection: "posts",
+			multiple: true,
+			value_field: "{{slug}}",
+			search_fields: ["title"],
+			display_fields: ["title"],
+		},
 	],
 };

--- a/src/pages/resource/[kind]/[id].page.tsx
+++ b/src/pages/resource/[kind]/[id].page.tsx
@@ -298,6 +298,7 @@ export default function ResourcePage(props: ResourcePageProps): JSX.Element {
 					<CourseLinks courses={courses} />
 					<Citation metadata={metadata} />
 					<ReUseConditions />
+					<Translations translations={metadata.translations} />
 				</aside>
 				<div className="min-w-0">
 					<Resource resource={resource} lastUpdatedAt={lastUpdatedAt} />
@@ -496,5 +497,38 @@ function RelatedResources(props: RelatedResourcesProps) {
 				})}
 			</ul>
 		</nav>
+	);
+}
+
+interface TranslationsProps {
+	translations: PostData["data"]["metadata"]["translations"];
+}
+
+function Translations(props: TranslationsProps) {
+	const { translations } = props;
+
+	const format = new Intl.DisplayNames(["en"], { type: "language" });
+
+	if (translations.length === 0) return null;
+
+	return (
+		<div className="space-y-1.5">
+			<h2 className="text-xs font-bold tracking-wide uppercase text-neutral-600">Translations</h2>
+			<ul role="list" className="grid gap-2">
+				{translations.map((translation) => {
+					return (
+						<li key={translation.id}>
+							<span>This resource is also available in {format.of(translation.lang)}: </span>
+							<Link
+								className="transition text-primary-600"
+								href={`/resource/posts/${translation.id}`}
+							>
+								{translation.title}
+							</Link>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
 	);
 }


### PR DESCRIPTION
this adds a new metadata field to resources, which allows linking to translations of a particular resource.

the metadata field is exposed in the cms as a multiselect.

on the resource page, translations are listed in the left-hand side-panel like this: "This resource is also available in English: <a>The title of the translated resource</a>".