### PR TITLE
Fix acdh

### DIFF
--- a/content/posts/cultural-heritage-some-observations-on-collecting-and-curating-in-the-digital-age/index.mdx
+++ b/content/posts/cultural-heritage-some-observations-on-collecting-and-curating-in-the-digital-age/index.mdx
@@ -14,7 +14,7 @@ tags:
   - digital-archives
 categories:
   - dariah
-abstract: In this webinar recording, Natalie Harrower shares her insights on difficulties, complexities and the need to get started on digital preservation in the cultural heritage domain. This talk explores why we should care, as a society, about digital preservation, and what opportunities the digital offers for the humanities and social sciences.  Part of the Digital Humanities webinar series from the Austrian Centre for Digital Humanities and Cultural Heritage (ADCH-CH).
+abstract: In this webinar recording, Natalie Harrower shares her insights on difficulties, complexities and the need to get started on digital preservation in the cultural heritage domain. This talk explores why we should care, as a society, about digital preservation, and what opportunities the digital offers for the humanities and social sciences.  Part of the Digital Humanities webinar series from the Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH).
 domain: Social Sciences and Humanities
 targetGroup: Domain researchers
 type: video

--- a/content/posts/digitality-and-music-editions-thinking-about-the-roles-of-editors/index.mdx
+++ b/content/posts/digitality-and-music-editions-thinking-about-the-roles-of-editors/index.mdx
@@ -13,7 +13,7 @@ tags:
   - scholarly-editions
 categories:
   - dariah
-abstract: In this lecture from the Austrian Centre for Digital Humanities and Cultural Heritage (ADCH-CH) entitled "Digitality and Music Editions".  Thinking about the Roles of Editors, Stefanie Acquavella-Rauch discusses digitality as a method as well as a phenomenon and its role in music editions. In this talk, digitality is discussed as inhibiting a significant role in how researchers' roles change according to their personal engagement with the digital.
+abstract: In this lecture from the Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH) entitled "Digitality and Music Editions".  Thinking about the Roles of Editors, Stefanie Acquavella-Rauch discusses digitality as a method as well as a phenomenon and its role in music editions. In this talk, digitality is discussed as inhibiting a significant role in how researchers' roles change according to their personal engagement with the digital.
 domain: Social Sciences and Humanities
 targetGroup: Domain researchers
 type: video

--- a/content/posts/greek-latin-classics-and-the-need-for-a-global-philology/index.mdx
+++ b/content/posts/greek-latin-classics-and-the-need-for-a-global-philology/index.mdx
@@ -14,7 +14,7 @@ tags:
 categories:
   - dariah
 abstract: In this lecture from the Austrian Centre for Digital Humanities and
-  Cultural Heritage (ADCH-CH), Professor Crane discusses the need for a global
+  Cultural Heritage (ACDH-CH), Professor Crane discusses the need for a global
   philology. Combining classical philology and computer science, Crane aims to
   apply computer-based methods to the study of human cultural development. He
   discusses the necessity for project oriented, research, reusable code and

--- a/content/posts/knowledge-design_/index.mdx
+++ b/content/posts/knowledge-design_/index.mdx
@@ -15,7 +15,7 @@ tags:
 categories:
   - dariah
 abstract: In this lecture from the Austrian Centre for Digital Humanities and
-  Cultural Heritage (ADCH-CH), Jeffrey Schnapp outlines the main questions which
+  Cultural Heritage (ACDH-CH), Jeffrey Schnapp outlines the main questions which
   Knowledge Design is concerned with. Schnapp provides an overview of the
   current situation of boundaries between libraries, museums, archives, and the
   classroom becoming growing porous. Additionally, he explores the role of

--- a/content/posts/looking-for-revolution-in-the-data-pool-some-observations-from-cesta-at-stanford/index.mdx
+++ b/content/posts/looking-for-revolution-in-the-data-pool-some-observations-from-cesta-at-stanford/index.mdx
@@ -17,7 +17,7 @@ categories:
   - dariah
 abstract: >
   In this lecture from the Austrian Centre for Digital Humanities and Cultural
-  Heritage (ADCH-CH), Keith Baker addresses the Digital Humanities dimensions of
+  Heritage (ACDH-CH), Keith Baker addresses the Digital Humanities dimensions of
   two projects ('Writing Rights' and 'Revolutionizing Revolution') against the
   academic background at Stanford. This lecture gives special attention to
   exploring the possibilities of digital archives as well as visualisation in

--- a/content/posts/shaping-the-unseen-behind-the-scenes-of-data-visualization/index.mdx
+++ b/content/posts/shaping-the-unseen-behind-the-scenes-of-data-visualization/index.mdx
@@ -14,7 +14,7 @@ tags:
 categories:
   - dariah
 abstract: In this lecture from the Austrian Centre for Digital Humanities and
-  Cultural Heritage (ADCH-CH), Jan Willem Tulp gives an overview of data
+  Cultural Heritage (ACDH-CH), Jan Willem Tulp gives an overview of data
   visualisation as a type of data representation. Additionally, he discusses
   types of visualisation such as impression or experience as well as case
   studies, such as the European Space Agency or Tulp's project on 2012 national

--- a/content/posts/things-that-poems-taught-me-about-visualization/index.mdx
+++ b/content/posts/things-that-poems-taught-me-about-visualization/index.mdx
@@ -15,7 +15,7 @@ categories:
   - dariah
 abstract: >
   In this lecture from the Austrian Centre for Digital Humanities and Cultural
-  Heritage (ADCH-CH), Miriah Meyer reflects on the question "why work with
+  Heritage (ACDH-CH), Miriah Meyer reflects on the question "why work with
   humanists as a computer scientist". She expands on how interdisciplinary
   collaborations with poetry scholars have shaped her own research thinking.
 domain: Social Sciences and Humanities

--- a/content/posts/virtual-reality-and-the-museum-library-sector-the-case-of-the-university-museum-and-library-of-trondheim/index.mdx
+++ b/content/posts/virtual-reality-and-the-museum-library-sector-the-case-of-the-university-museum-and-library-of-trondheim/index.mdx
@@ -16,7 +16,7 @@ tags:
 categories:
   - dariah
 abstract: In this lecture from the Austrian Centre for Digital Humanities and
-  Cultural Heritage (ADCH-CH), Alexandra Angeletaki asks whether the
+  Cultural Heritage (ACDH-CH), Alexandra Angeletaki asks whether the
   introduction of VR tools in dissemination practices has led to a change in the
   experience of the contemporary museum perception. By using the case of the
   Archaeological Museum and the library in Trondheim, Norway, she explores the

--- a/content/posts/visual-analytics-enabling-images-to-speak-for-themselves/index.mdx
+++ b/content/posts/visual-analytics-enabling-images-to-speak-for-themselves/index.mdx
@@ -16,7 +16,7 @@ categories:
   - dariah
 featuredImage: ""
 abstract: In this lecture from the Austrian Centre for Digital Humanities and
-  Cultural Heritage (ADCH-CH), Björn Ommer discusses Visual Analytics's concern
+  Cultural Heritage (ACDH-CH), Björn Ommer discusses Visual Analytics's concern
   of how to teach machines to enable visuals to speak for themselves. Pointing
   out the current inadequacy of research tools in the humanities, Ommer
   discusses questions such as "How would research in the humanities benefit if

--- a/content/posts/what-300-dimensional-fridges-can-tell-us-about-language/index.mdx
+++ b/content/posts/what-300-dimensional-fridges-can-tell-us-about-language/index.mdx
@@ -15,7 +15,7 @@ tags:
 categories:
   - dariah
 abstract: In this lecture from the Austrian Centre for Digital Humanities and
-  Cultural Heritage (ADCH-CH), Dirk Hovy gives an introduction to the method
+  Cultural Heritage (ACDH-CH), Dirk Hovy gives an introduction to the method
   called embeddings, and showcases several applications of it. Hovy shows how
   they capture regional variation at an intra- and interlingual level, how they
   distinguish varieties and linguistic resources, and how they allow for the


### PR DESCRIPTION
This fixes the ACDH-CH name in the ACDH-CH lecture posts where the name had a typo (ADCH).