### PR TITLE
feat: add heading-id link type

### DIFF
--- a/lib/keystatic/components.tsx
+++ b/lib/keystatic/components.tsx
@@ -250,7 +250,7 @@ export const createGrid = createComponent((_paths, _locale) => {
 export const createHeadingId = createComponent((_paths, _locale) => {
 	return {
 		HeadingId: inline({
-			label: "HeadingId",
+			label: "Heading identifier",
 			description: "Add a custom link target to a heading.",
 			icon: <HashIcon />,
 			schema: {

--- a/lib/keystatic/create-link-schema.ts
+++ b/lib/keystatic/create-link-schema.ts
@@ -1,12 +1,13 @@
 import { createAssetOptions, type Paths, withI18nPrefix } from "@acdh-oeaw/keystatic-lib";
 import { fields } from "@keystatic/core";
 
-import type { Locale } from "@/config/i18n.config";
+import type { Language } from "@/config/i18n.config";
 import { linkKinds } from "@/lib/content/options";
+import * as validation from "@/lib/keystatic/validation";
 
 export function createLinkSchema<TPath extends `/${string}/`>(
 	downloadPath: Paths<TPath>["downloadPath"],
-	locale: Locale,
+	locale: Language,
 ) {
 	return fields.conditional(
 		fields.select({
@@ -28,6 +29,10 @@ export function createLinkSchema<TPath extends `/${string}/`>(
 			external: fields.url({
 				label: "URL",
 				validation: { isRequired: true },
+			}),
+			"url-fragment-id": fields.text({
+				label: "Heading identifier",
+				validation: { isRequired: true, pattern: validation.urlFragment },
 			}),
 			curricula: fields.relationship({
 				label: "Curriculum",

--- a/lib/keystatic/get-link-props.ts
+++ b/lib/keystatic/get-link-props.ts
@@ -18,6 +18,10 @@ export function getLinkProps(params: LinkSchema) {
 			return { href: params.value };
 		}
 
+		case "url-fragment-id": {
+			return { href: `#${params.value}` };
+		}
+
 		case "curricula": {
 			return { href: `/curricula/${params.value}` };
 		}

--- a/lib/keystatic/validation.ts
+++ b/lib/keystatic/validation.ts
@@ -7,3 +7,8 @@
 export const email = { regex: /.+?@.+?/, message: "Must be a valid email address." };
 
 export const twitter = { regex: /^@.+/, message: "Must start with an '@' character." };
+
+export const urlFragment = {
+	regex: /^[^#].+/,
+	message: "Must not include the leading '#' character.",
+};


### PR DESCRIPTION
this adds a new "Heading identifier" type to the `<Link>` widget, which can be used in tandem with the `<HeadingId>` widget, i.e. when adding a custom identifier to a heading with the `<HeadingId>` widget, this identifier can then be used in a `<Link>` widget of type "Heading identifier" to create in-document links to that headings.