### PR TITLE
feat: add plain callout type

### DIFF
--- a/components/content/callout.tsx
+++ b/components/content/callout.tsx
@@ -1,4 +1,4 @@
-import { capitalize } from "@acdh-oeaw/lib";
+import { capitalize, isNonEmptyString } from "@acdh-oeaw/lib";
 import { styles } from "@acdh-oeaw/style-variants";
 import {
 	AlertTriangleIcon,
@@ -12,7 +12,7 @@ import type { ReactNode } from "react";
 
 import type { CalloutKind } from "@/lib/content/options";
 
-const icons: Record<CalloutKind, LucideIcon> = {
+const icons: Record<Exclude<CalloutKind, "none">, LucideIcon> = {
 	caution: BoltIcon,
 	important: InfoIcon,
 	note: PencilIcon,
@@ -21,14 +21,16 @@ const icons: Record<CalloutKind, LucideIcon> = {
 };
 
 const calloutStyles = styles({
-	base: "my-12 grid gap-y-3 rounded-md border border-l-4 p-6 shadow [&_*::marker]:text-inherit [&_*]:text-inherit",
+	base: "my-12 grid gap-y-3 rounded-md border p-6 shadow [&_*::marker]:text-inherit [&_*]:text-inherit",
 	variants: {
 		kind: {
-			caution: "border-error-200 border-l-error-600 bg-error-50 text-error-800",
-			important: "border-important-200 border-l-important-600 bg-important-50 text-important-800",
-			note: "border-neutral-200 border-l-neutral-600 bg-neutral-100 text-neutral-800",
-			tip: "border-success-200 border-l-success-600 bg-success-50 text-success-800",
-			warning: "border-warning-200 border-l-warning-500 bg-warning-50 text-warning-800",
+			caution: "border-l-4 border-error-200 border-l-error-600 bg-error-50 text-error-800",
+			important:
+				"border-l-4 border-important-200 border-l-important-600 bg-important-50 text-important-800",
+			note: "border-l-4 border-neutral-200 border-l-neutral-600 bg-neutral-100 text-neutral-800",
+			tip: "border-l-4 border-success-200 border-l-success-600 bg-success-50 text-success-800",
+			warning: "border-l-4 border-warning-200 border-l-warning-500 bg-warning-50 text-warning-800",
+			none: "border-neutral-200 bg-neutral-100 text-neutral-800",
 		},
 	},
 	defaults: {
@@ -46,17 +48,40 @@ interface CalloutProps {
 export function Callout(props: Readonly<CalloutProps>): ReactNode {
 	const { children, kind = "note", title } = props;
 
-	const Icon = icons[kind];
-
 	return (
 		<aside className={calloutStyles({ kind })}>
-			<strong className="flex items-center gap-x-2 font-bold">
-				<Icon aria-hidden={true} className="size-5 shrink-0" />
-				<span>{title ?? capitalize(kind)}</span>
-			</strong>
+			<CalloutHeader kind={kind} title={title} />
 			<div className="[&_:first-child]:mt-0 [&_:last-child]:mb-0 [&_a:hover]:no-underline [&_a]:underline">
 				{children}
 			</div>
 		</aside>
 	);
+}
+
+interface CalloutHeaderProps {
+	kind: CalloutKind;
+	title?: string;
+}
+
+function CalloutHeader(props: CalloutHeaderProps): ReactNode {
+	const { kind, title } = props;
+
+	const hasTitle = isNonEmptyString(title);
+
+	if (kind !== "none") {
+		const Icon = icons[kind];
+
+		return (
+			<strong className="flex items-center gap-x-2 font-bold">
+				<Icon aria-hidden={true} className="size-5 shrink-0" />
+				<span>{hasTitle ? title : capitalize(kind)}</span>
+			</strong>
+		);
+	}
+
+	if (hasTitle) {
+		return <strong className="font-bold">{title}</strong>;
+	}
+
+	return null;
 }

--- a/lib/content/options.ts
+++ b/lib/content/options.ts
@@ -4,6 +4,7 @@ export const calloutKinds = [
 	{ label: "Note", value: "note" },
 	{ label: "Tip", value: "tip" },
 	{ label: "Warning", value: "warning" },
+	{ label: "Plain", value: "none" },
 ] as const;
 
 export type CalloutKind = (typeof calloutKinds)[number]["value"];

--- a/lib/keystatic/previews.tsx
+++ b/lib/keystatic/previews.tsx
@@ -26,7 +26,7 @@ import { createVideoUrl } from "@/lib/keystatic/create-video-url";
 
 type LinkSchema = ParsedValueForComponentSchema<ReturnType<typeof createLinkSchema>>;
 
-const calloutIcons: Record<CalloutKind, LucideIcon> = {
+const calloutIcons: Record<Exclude<CalloutKind, "none">, LucideIcon> = {
 	caution: BoltIcon,
 	important: InfoIcon,
 	note: PencilIcon,
@@ -35,14 +35,16 @@ const calloutIcons: Record<CalloutKind, LucideIcon> = {
 };
 
 const calloutStyles = styles({
-	base: "grid gap-y-3 rounded-md border border-l-4 p-6 shadow [&_*::marker]:text-inherit [&_*]:text-inherit",
+	base: "grid gap-y-3 rounded-md border p-6 shadow [&_*::marker]:text-inherit [&_*]:text-inherit",
 	variants: {
 		kind: {
-			caution: "border-error-200 border-l-error-600 bg-error-50 text-error-800",
-			important: "border-important-200 border-l-important-600 bg-important-50 text-important-800",
-			note: "border-neutral-200 border-l-neutral-600 bg-neutral-100 text-neutral-800",
-			tip: "border-success-200 border-l-success-600 bg-success-50 text-success-800",
-			warning: "border-warning-200 border-l-warning-500 bg-warning-50 text-warning-800",
+			caution: "border-l-4 border-error-200 border-l-error-600 bg-error-50 text-error-800",
+			important:
+				"border-l-4 border-important-200 border-l-important-600 bg-important-50 text-important-800",
+			note: "border-l-4 border-neutral-200 border-l-neutral-600 bg-neutral-100 text-neutral-800",
+			tip: "border-l-4 border-success-200 border-l-success-600 bg-success-50 text-success-800",
+			warning: "border-l-4 border-warning-200 border-l-warning-500 bg-warning-50 text-warning-800",
+			none: "border-neutral-200 bg-neutral-100 text-neutral-800",
 		},
 	},
 	defaults: {
@@ -60,20 +62,42 @@ interface CalloutPreviewProps {
 export function CalloutPreview(props: Readonly<CalloutPreviewProps>): ReactNode {
 	const { children, kind = "note", title } = props;
 
-	const Icon = calloutIcons[kind];
-
 	return (
 		<aside className={calloutStyles({ kind })}>
 			<NotEditable>
-				<strong className="flex items-center gap-x-2 font-bold">
-					<Icon aria-hidden={true} className="size-5 shrink-0" />
-					{/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-					<span>{title || capitalize(kind)}</span>
-				</strong>
+				<CalloutPreviewHeader kind={kind} title={title} />
 			</NotEditable>
 			<div className="[&_a:hover]:no-underline [&_a]:underline">{children}</div>
 		</aside>
 	);
+}
+
+interface CalloutPreviewHeaderProps {
+	kind: CalloutKind;
+	title?: string;
+}
+
+function CalloutPreviewHeader(props: CalloutPreviewHeaderProps): ReactNode {
+	const { kind, title } = props;
+
+	const hasTitle = isNonEmptyString(title);
+
+	if (kind !== "none") {
+		const Icon = calloutIcons[kind];
+
+		return (
+			<strong className="flex items-center gap-x-2 font-bold">
+				<Icon aria-hidden={true} className="size-5 shrink-0" />
+				<span>{hasTitle ? title : capitalize(kind)}</span>
+			</strong>
+		);
+	}
+
+	if (hasTitle) {
+		return <strong className="font-bold">{title}</strong>;
+	}
+
+	return null;
 }
 
 interface DisclosurePreviewProps {


### PR DESCRIPTION
this adds a new type of `Callout` widget, which does not display an icon, and marks the title as optional. should be used sparingly.