### PR TITLE
feat: allow hash and query on link widget

### DIFF
--- a/content/en/documentation/reuse-charter/index.mdx
+++ b/content/en/documentation/reuse-charter/index.mdx
@@ -10,7 +10,7 @@ Fostering **open access to scholarly resources**, as well as collaboration and f
 
 ## Reciprocity
 
-DARIAH-Campus is a platform where content providers can meet with content users (acknowledging that a significant portion of the scholarly communities usually fulfil both roles anyway). Reciprocity is a core value in the design and operation of our platform as it gives the opportunity for creators of training materials to <Link link={{"discriminant":"documentation","value":"proposing-a-contribution"}}>share their content</Link> in a sustainable way, while learners ((re)users) are encouraged to share their feedback but also contribute new training materials. To facilitate the exchange, contact information of both authors (together with other contributors) and commenters/reviewers will be made explicit.
+DARIAH-Campus is a platform where content providers can meet with content users (acknowledging that a significant portion of the scholarly communities usually fulfil both roles anyway). Reciprocity is a core value in the design and operation of our platform as it gives the opportunity for creators of training materials to <Link link={{"discriminant":"documentation","value":{"id":"proposing-a-contribution"}}}>share their content</Link> in a sustainable way, while learners ((re)users) are encouraged to share their feedback but also contribute new training materials. To facilitate the exchange, contact information of both authors (together with other contributors) and commenters/reviewers will be made explicit.
 
 ## Interoperability
 

--- a/content/en/documentation/types-of-resources/index.mdx
+++ b/content/en/documentation/types-of-resources/index.mdx
@@ -17,23 +17,23 @@ Within DARIAH-Campus, users can find different types of learning resources, and 
 
 One of the functions of DARIAH-Campus is to act as a discovery layer for existing learning resources, which includes curated links to lessons, courses, tutorials and other materials in the places where they 'live'. Currently, we link to resources that a) have a connection with DARIAH-EU or the national nodes; b) are contributions from our members; and/or c) have a connection with the DARIAH Working Groups. We only link to external resources that are openly available for use and re-use in order to promote and uphold the principles of open science.
 
-You can see an example an externally hosted resource <Link link={{"discriminant":"resources-external","value":"citizen-science-in-the-digital-arts-and-humanities"}}>here</Link>.
+You can see an example an externally hosted resource <Link link={{"discriminant":"resources-external","value":{"id":"citizen-science-in-the-digital-arts-and-humanities"}}}>here</Link>.
 
 ### Hosted resources
 
 DARIAH-Campus hosts and version-controls new online learning resources designed for use both by online users and in future face-to-facing training events. Hosted resources include, but are not limited to: training courses, individual lessons, and/or tutorials. These hosted resources cover topics and concepts related to (digital) humanities scholarship, and range from very targeted courses around a particular tool or methodology, such as GIS or TEI, to more universal issues related to current humanities scholarship such as Open Science, or Research Data Management.
 
-To view an example of a hosted resource, <Link link={{"discriminant":"resources-hosted","value":"xpath-for-dictionary-nerds"}}>click here</Link>.
+To view an example of a hosted resource, <Link link={{"discriminant":"resources-hosted","value":{"id":"xpath-for-dictionary-nerds"}}}>click here</Link>.
 
 ### Pathfinders
 
 There is an overwhelming number of learning resources available online, so much so that it is sometimes quite difficult for learners to know where to start. In such cases, DARIAH Pathfinders come to rescue as specially-produced, humanist-friendly guides on a variety of topics relating to digitally-enabled research and teaching. A Pathfinder is a 'hybrid' resource which is written for and hosted by DARIAH-CAMPUS, but which introduces and contextualises a number of other resources, including those that are hosted externally and those that extend beyond those created by members of the DARIAH network.
 
-You can see an example of a Pathfinder <Link link={{"discriminant":"resources-pathfinders","value":"dariah-pathfinder-to-data-management-best-practices-in-the-humanities"}}>here</Link>.
+You can see an example of a Pathfinder <Link link={{"discriminant":"resources-pathfinders","value":{"id":"dariah-pathfinder-to-data-management-best-practices-in-the-humanities"}}}>here</Link>.
 
 ### Events
 
 The ephemeral nature of training events such as webinars, lectures series or training workshops can be tricky to reproduce in an online environment, yet they are a vitally important part of training and education. DARIAH-Campus offers a format that captures live training events such as these to enable learners and trainers to revisit and reuse the outputs of such events. We do this by hosting documentation from these events, which can include programmes, slides, videos, speaker biographies and much more. For this, we have designed a special workflow and a template to compile and structure the content in a learner-friendly way.
 
-For an example of a captured event on DARIAH-Campus see <Link link={{"discriminant":"resources-events","value":"open-data-citation-for-social-science-and-humanities"}}>here</Link>.
+For an example of a captured event on DARIAH-Campus see <Link link={{"discriminant":"resources-events","value":{"id":"open-data-citation-for-social-science-and-humanities"}}}>here</Link>.
 

--- a/content/en/resources/events/explore-cor-using-programmable-corpora-in-computational-literary-studies/index.mdx
+++ b/content/en/resources/events/explore-cor-using-programmable-corpora-in-computational-literary-studies/index.mdx
@@ -227,7 +227,7 @@ The following software was used during more practical aspects of this workshop. 
 
 #### Gephi
 
-Download and install the latest version of "Gephi" (<Link link={{"discriminant":"external"}}>[https://gephi.org](https://gephi.org)</Link>)
+Download and install the latest version of "Gephi" ([https://gephi.org](https://gephi.org))
 
 #### Docker
 
@@ -243,7 +243,7 @@ Börner, I., & Trilcke, P. (2024). CLS INFRA D7.3 On Versioning Living and Progr
 
 Ďurčo, M., Charvat, V. M., Börner, I., Mrugalski, M., & Odebrecht, C. (2022). CLS INFRA D6.1 Inventory of existing data sources and formats. Zenodo. ([https://doi.org/10.5281/zenodo.7520287](https://doi.org/10.5281/zenodo.7520287))
 
-Ďurčo, M., Charvát, V. M., & Resch, S. (2025). CLS INFRA D6.2 Transformation toolbox & ingest and processing workflow. Zenodo. <Link link={{"discriminant":"external"}}>[https://doi.org/10.5281/zenodo.14998374](https://doi.org/10.5281/zenodo.14998374)</Link>
+Ďurčo, M., Charvát, V. M., & Resch, S. (2025). CLS INFRA D6.2 Transformation toolbox & ingest and processing workflow. Zenodo. ([https://doi.org/10.5281/zenodo.14998374](https://doi.org/10.5281/zenodo.14998374))
 
 Mrugalski, M., Odebrecht, C., Charvat, V., Börner, I., & Durco, M. (2022). CLS INFRA D5.1. Review of the Data Landscape. Zenodo. ([https://doi.org/10.5281/zenodo.6861022](https://doi.org/10.5281/zenodo.6861022))
 

--- a/lib/content/options.ts
+++ b/lib/content/options.ts
@@ -59,14 +59,14 @@ export type GridLayout = (typeof gridLayouts)[number]["value"];
 
 export const linkKinds = [
 	{ label: "Direct URL", value: "external" },
-	{ label: "Documentation", value: "documentation" },
-	{ label: "Download", value: "download" },
 	{ label: "Heading identifier", value: "url-fragment-id" },
-	{ label: "Curricula", value: "curricula" },
+	{ label: "Download", value: "download" },
 	{ label: "Events", value: "resources-events" },
 	{ label: "External resources", value: "resources-external" },
 	{ label: "Hosted resources", value: "resources-hosted" },
 	{ label: "Pathfinders", value: "resources-pathfinders" },
+	{ label: "Curricula", value: "curricula" },
+	{ label: "Documentation", value: "documentation" },
 ] as const;
 
 export type LinkKind = (typeof linkKinds)[number]["value"];

--- a/lib/content/options.ts
+++ b/lib/content/options.ts
@@ -59,13 +59,14 @@ export type GridLayout = (typeof gridLayouts)[number]["value"];
 
 export const linkKinds = [
 	{ label: "Direct URL", value: "external" },
-	{ label: "Heading identifier", value: "url-fragment-id" },
+	{ label: "Heading identifier", value: "hash" },
 	{ label: "Download", value: "download" },
 	{ label: "Events", value: "resources-events" },
 	{ label: "External resources", value: "resources-external" },
 	{ label: "Hosted resources", value: "resources-hosted" },
 	{ label: "Pathfinders", value: "resources-pathfinders" },
 	{ label: "Curricula", value: "curricula" },
+	{ label: "Search", value: "search" },
 	{ label: "Documentation", value: "documentation" },
 ] as const;
 

--- a/lib/keystatic/create-link-schema.ts
+++ b/lib/keystatic/create-link-schema.ts
@@ -16,16 +16,6 @@ export function createLinkSchema<TPath extends `/${string}/`>(
 			defaultValue: "external",
 		}),
 		{
-			documentation: fields.relationship({
-				label: "Documentation",
-				validation: { isRequired: true },
-				collection: withI18nPrefix("documentation", locale),
-			}),
-			download: fields.file({
-				label: "Download",
-				validation: { isRequired: true },
-				...createAssetOptions(downloadPath),
-			}),
 			external: fields.url({
 				label: "URL",
 				validation: { isRequired: true },
@@ -34,10 +24,10 @@ export function createLinkSchema<TPath extends `/${string}/`>(
 				label: "Heading identifier",
 				validation: { isRequired: true, pattern: validation.urlFragment },
 			}),
-			curricula: fields.relationship({
-				label: "Curriculum",
+			download: fields.file({
+				label: "Download",
 				validation: { isRequired: true },
-				collection: withI18nPrefix("curricula", locale),
+				...createAssetOptions(downloadPath),
 			}),
 			"resources-events": fields.relationship({
 				label: "Event",
@@ -58,6 +48,16 @@ export function createLinkSchema<TPath extends `/${string}/`>(
 				label: "Pathfinder",
 				validation: { isRequired: true },
 				collection: withI18nPrefix("resources-pathfinders", locale),
+			}),
+			curricula: fields.relationship({
+				label: "Curriculum",
+				validation: { isRequired: true },
+				collection: withI18nPrefix("curricula", locale),
+			}),
+			documentation: fields.relationship({
+				label: "Documentation",
+				validation: { isRequired: true },
+				collection: withI18nPrefix("documentation", locale),
 			}),
 		},
 	);

--- a/lib/keystatic/create-link-schema.ts
+++ b/lib/keystatic/create-link-schema.ts
@@ -20,8 +20,9 @@ export function createLinkSchema<TPath extends `/${string}/`>(
 				label: "URL",
 				validation: { isRequired: true },
 			}),
-			"url-fragment-id": fields.text({
+			hash: fields.text({
 				label: "Heading identifier",
+				description: "For example `#first-heading`.",
 				validation: { isRequired: true, pattern: validation.urlFragment },
 			}),
 			download: fields.file({
@@ -29,35 +30,89 @@ export function createLinkSchema<TPath extends `/${string}/`>(
 				validation: { isRequired: true },
 				...createAssetOptions(downloadPath),
 			}),
-			"resources-events": fields.relationship({
-				label: "Event",
-				validation: { isRequired: true },
-				collection: withI18nPrefix("resources-events", locale),
+			"resources-events": fields.object({
+				id: fields.relationship({
+					label: "Event",
+					validation: { isRequired: true },
+					collection: withI18nPrefix("resources-events", locale),
+				}),
+				hash: fields.text({
+					label: "URL fragment",
+					description: "For example `#first-heading`.",
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
+				}),
 			}),
-			"resources-external": fields.relationship({
-				label: "External resource",
-				validation: { isRequired: true },
-				collection: withI18nPrefix("resources-external", locale),
+			"resources-external": fields.object({
+				id: fields.relationship({
+					label: "External resource",
+					validation: { isRequired: true },
+					collection: withI18nPrefix("resources-external", locale),
+				}),
+				hash: fields.text({
+					label: "URL fragment",
+					description: "For example `#first-heading`.",
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
+				}),
 			}),
-			"resources-hosted": fields.relationship({
-				label: "Hosted resource",
-				validation: { isRequired: true },
-				collection: withI18nPrefix("resources-hosted", locale),
+			"resources-hosted": fields.object({
+				id: fields.relationship({
+					label: "Hosted resource",
+					validation: { isRequired: true },
+					collection: withI18nPrefix("resources-hosted", locale),
+				}),
+				hash: fields.text({
+					label: "URL fragment",
+					description: "For example `#first-heading`.",
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
+				}),
 			}),
-			"resources-pathfinders": fields.relationship({
-				label: "Pathfinder",
-				validation: { isRequired: true },
-				collection: withI18nPrefix("resources-pathfinders", locale),
+			"resources-pathfinders": fields.object({
+				id: fields.relationship({
+					label: "Pathfinder",
+					validation: { isRequired: true },
+					collection: withI18nPrefix("resources-pathfinders", locale),
+				}),
+				hash: fields.text({
+					label: "URL fragment",
+					description: "For example `#first-heading`.",
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
+				}),
 			}),
-			curricula: fields.relationship({
-				label: "Curriculum",
-				validation: { isRequired: true },
-				collection: withI18nPrefix("curricula", locale),
+			curricula: fields.object({
+				id: fields.relationship({
+					label: "Curriculum",
+					validation: { isRequired: true },
+					collection: withI18nPrefix("curricula", locale),
+				}),
+				hash: fields.text({
+					label: "URL fragment",
+					description: "For example `#first-heading`.",
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
+				}),
 			}),
-			documentation: fields.relationship({
-				label: "Documentation",
-				validation: { isRequired: true },
-				collection: withI18nPrefix("documentation", locale),
+			search: fields.object({
+				search: fields.text({
+					label: "Search params",
+					description: "For example `?q=dariah`.",
+					validation: { isRequired: false, pattern: validation.urlSearchParamsOptional },
+				}),
+				hash: fields.text({
+					label: "URL fragment",
+					description: "For example `#first-heading`.",
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
+				}),
+			}),
+			documentation: fields.object({
+				id: fields.relationship({
+					label: "Documentation",
+					validation: { isRequired: true },
+					collection: withI18nPrefix("documentation", locale),
+				}),
+				hash: fields.text({
+					label: "URL fragment",
+					description: "For example `#first-heading`.",
+					validation: { isRequired: false, pattern: validation.urlFragmentOptional },
+				}),
 			}),
 		},
 	);

--- a/lib/keystatic/get-link-props.ts
+++ b/lib/keystatic/get-link-props.ts
@@ -1,5 +1,6 @@
 import type { ValueForReading } from "@keystatic/core";
 
+import { createHref } from "@/lib/create-href";
 import type { createLinkSchema } from "@/lib/keystatic/create-link-schema";
 
 export type LinkSchema = ValueForReading<ReturnType<typeof createLinkSchema>>;
@@ -7,39 +8,87 @@ export type LinkSchema = ValueForReading<ReturnType<typeof createLinkSchema>>;
 export function getLinkProps(params: LinkSchema) {
 	switch (params.discriminant) {
 		case "curricula": {
-			return { href: `/curricula/${params.value}` };
+			return {
+				href: createHref({
+					pathname: `/curricula/${params.value.id}`,
+					hash: params.value.hash,
+				}),
+			};
 		}
 
 		case "documentation": {
-			return { href: `/documentation/${params.value}` };
+			return {
+				href: createHref({
+					pathname: `/documentation/${params.value.id}`,
+					hash: params.value.hash,
+				}),
+			};
 		}
 
 		case "download": {
-			return { download: true, href: params.value };
+			return {
+				download: true,
+				href: params.value,
+			};
 		}
 
 		case "external": {
-			return { href: params.value };
+			return {
+				href: params.value,
+			};
+		}
+
+		case "hash": {
+			return {
+				href: createHref({
+					hash: params.value,
+				}),
+			};
 		}
 
 		case "resources-events": {
-			return { href: `/resources/events/${params.value}` };
+			return {
+				href: createHref({
+					pathname: `/resources/events/${params.value.id}`,
+					hash: params.value.hash,
+				}),
+			};
 		}
 
 		case "resources-external": {
-			return { href: `/resources/external/${params.value}` };
+			return {
+				href: createHref({
+					pathname: `/resources/external/${params.value.id}`,
+					hash: params.value.hash,
+				}),
+			};
 		}
 
 		case "resources-hosted": {
-			return { href: `/resources/hosted/${params.value}` };
+			return {
+				href: createHref({
+					pathname: `/resources/hosted/${params.value.id}`,
+					hash: params.value.hash,
+				}),
+			};
 		}
 
 		case "resources-pathfinders": {
-			return { href: `/resources/pathfinders/${params.value}` };
+			return {
+				href: createHref({
+					pathname: `/resources/pathfinders/${params.value.id}`,
+					hash: params.value.hash,
+				}),
+			};
 		}
 
-		case "url-fragment-id": {
-			return { href: `#${params.value}` };
+		case "search": {
+			return {
+				href: createHref({
+					pathname: "/search",
+					searchParams: params.value.search,
+				}),
+			};
 		}
 	}
 }

--- a/lib/keystatic/get-link-props.ts
+++ b/lib/keystatic/get-link-props.ts
@@ -6,6 +6,10 @@ export type LinkSchema = ValueForReading<ReturnType<typeof createLinkSchema>>;
 
 export function getLinkProps(params: LinkSchema) {
 	switch (params.discriminant) {
+		case "curricula": {
+			return { href: `/curricula/${params.value}` };
+		}
+
 		case "documentation": {
 			return { href: `/documentation/${params.value}` };
 		}
@@ -16,14 +20,6 @@ export function getLinkProps(params: LinkSchema) {
 
 		case "external": {
 			return { href: params.value };
-		}
-
-		case "url-fragment-id": {
-			return { href: `#${params.value}` };
-		}
-
-		case "curricula": {
-			return { href: `/curricula/${params.value}` };
 		}
 
 		case "resources-events": {
@@ -40,6 +36,10 @@ export function getLinkProps(params: LinkSchema) {
 
 		case "resources-pathfinders": {
 			return { href: `/resources/pathfinders/${params.value}` };
+		}
+
+		case "url-fragment-id": {
+			return { href: `#${params.value}` };
 		}
 	}
 }

--- a/lib/keystatic/validation.ts
+++ b/lib/keystatic/validation.ts
@@ -9,6 +9,16 @@ export const email = { regex: /.+?@.+?/, message: "Must be a valid email address
 export const twitter = { regex: /^@.+/, message: "Must start with an '@' character." };
 
 export const urlFragment = {
-	regex: /^[^#].+/,
-	message: "Must not include the leading '#' character.",
+	regex: /^#.+/,
+	message: "Must include the leading '#' character.",
+};
+
+export const urlFragmentOptional = {
+	regex: /^$|^#.+/,
+	message: "Must include the leading '#' character.",
+};
+
+export const urlSearchParamsOptional = {
+	regex: /^$|^\?.+/,
+	message: "Must include the leading '?' character.",
 };


### PR DESCRIPTION
- [x] allows adding url fragments (`#first-heading`) to resource links added via `<Link>` widget - this enables adding links like [here](https://github.com/DARIAH-ERIC/dariah-campus/pull/1471#discussion_r2080120339)
- [x] adds a separate link type for `/search`, which also allows adding query params
- [x] migrates existing `<Link>` widgets (only a few in documentation pages)

see https://github.com/DARIAH-ERIC/dariah-campus/pull/1471#discussion_r2083114186 for screenshot of updated UI