### PR TITLE
fix: add field descriptions to cms fields

### DIFF
--- a/lib/keystatic/collections.tsx
+++ b/lib/keystatic/collections.tsx
@@ -176,7 +176,8 @@ export const createCurricula = createCollection("/curricula/", (paths, locale) =
 				collection: withI18nPrefix("curricula", locale),
 			}),
 			doi: _fields.identifier({
-				label: "DOI (readonly)",
+				label: "PID (readonly)",
+				description: "Automatically assigned Handle PID.",
 			}),
 		},
 	});
@@ -705,7 +706,8 @@ export const createEvents = createCollection("/resources/events/", (paths, local
 				collection: withI18nPrefix("resources-events", locale),
 			}),
 			doi: _fields.identifier({
-				label: "DOI (readonly)",
+				label: "PID (readonly)",
+				description: "Automatically assigned Handle PID.",
 			}),
 			draft: fields.ignored(),
 		},
@@ -963,7 +965,8 @@ export const createResourcesExternal = createCollection("/resources/external/", 
 				collection: withI18nPrefix("resources-external", locale),
 			}),
 			doi: _fields.identifier({
-				label: "DOI (readonly)",
+				label: "PID (readonly)",
+				description: "Automatically assigned Handle PID.",
 			}),
 			draft: fields.ignored(),
 		},
@@ -1093,7 +1096,8 @@ export const createResourcesHosted = createCollection("/resources/hosted/", (pat
 				collection: withI18nPrefix("resources-hosted", locale),
 			}),
 			doi: _fields.identifier({
-				label: "DOI (readonly)",
+				label: "PID (readonly)",
+				description: "Automatically assigned Handle PID.",
 			}),
 			draft: fields.ignored(),
 		},
@@ -1220,7 +1224,8 @@ export const createResourcesPathfinders = createCollection(
 					collection: withI18nPrefix("resources-pathfinders", locale),
 				}),
 				doi: _fields.identifier({
-					label: "DOI (readonly)",
+					label: "PID (readonly)",
+					description: "Automatically assigned Handle PID.",
 				}),
 				draft: fields.ignored(),
 			},

--- a/lib/keystatic/components.tsx
+++ b/lib/keystatic/components.tsx
@@ -168,6 +168,7 @@ export const createFigure = createComponent((paths, _locale) => {
 				}),
 				alt: fields.text({
 					label: "Image description for assistive technology",
+					description: "Leave empty if the image is only presentational",
 					validation: { isRequired: false },
 				}),
 				alignment: fields.select({

--- a/lib/keystatic/components.tsx
+++ b/lib/keystatic/components.tsx
@@ -168,7 +168,7 @@ export const createFigure = createComponent((paths, _locale) => {
 				}),
 				alt: fields.text({
 					label: "Image description for assistive technology",
-					description: "Leave empty if the image is only presentational",
+					description: "Leave empty if the image is only decorative or already explained in the text",
 					validation: { isRequired: false },
 				}),
 				alignment: fields.select({


### PR DESCRIPTION
- adds description to `alt` field on `Figure` widget: "Leave empty if the image is only presentational."

- adds description to read-only PID fields: "Automatically assigned Handle PID."

