### PR TITLE
chore: change cms section label from metadata to settings

### DIFF
--- a/keystatic.config.tsx
+++ b/keystatic.config.tsx
@@ -78,7 +78,7 @@ export default config({
 				withI18nPrefix("index-page", defaultLanguage),
 				withI18nPrefix("documentation", defaultLanguage),
 			],
-			Metadata: [
+			Settings: [
 				withI18nPrefix("navigation", defaultLanguage),
 				withI18nPrefix("metadata", defaultLanguage),
 			],


### PR DESCRIPTION
this changes the label of the "Metadata" section to "Settings", since "Metadata" is already an entry in this section (next to "Navigation").