### PR TITLE
fix: remove imprint double heading

### DIFF
--- a/app/(app)/(default)/_components/default-footer.tsx
+++ b/app/(app)/(default)/_components/default-footer.tsx
@@ -169,7 +169,7 @@ export function DefaultFooter(props: Readonly<DefaultFooterProps>): ReactNode {
 				<Suspense>
 					<CopyrightNotice />
 				</Suspense>
-				&bull;
+				<span> &bull; </span>
 				<Link
 					className="rounded transition hover:text-white focus:outline-none focus-visible:ring focus-visible:ring-neutral-400"
 					href={createHref({ pathname: "/imprint" })}

--- a/content/en/legal-notice/index.mdx
+++ b/content/en/legal-notice/index.mdx
@@ -1,7 +1,3 @@
----
-title: Imprint
----
-
 ## Legal Notice
 
 ### Address


### PR DESCRIPTION
removes a second superfluous heading on the imprint page and fixes spacing in the footer link.