### PR TITLE
fix: validate video ids

### DIFF
--- a/content/en/resources/events/building-and-linking-humanities-digital-spatial-infrastructures-for-research-in-the-nordic-countries/sessions/0/content.mdx
+++ b/content/en/resources/events/building-and-linking-humanities-digital-spatial-infrastructures-for-research-in-the-nordic-countries/sessions/0/content.mdx
@@ -1,5 +1,5 @@
 The talk addresses implementation of Linked Open Data in the Swedish cultural heritage sector with SOCH (Swedish Open Cultural Heritage) as its main example. Challenges of updating bespoke legacy solutions in order to achieve greater compatibility with overarching aggregators such as Europeana are also illuminated.
 
-<Video provider="youtube" id="https://www.youtube.com/embed/Sqyff632Y2M">
+<Video provider="youtube" id="Sqyff632Y2M">
   Presentation by Marcus Smith
 </Video>

--- a/content/en/resources/events/building-and-linking-humanities-digital-spatial-infrastructures-for-research-in-the-nordic-countries/sessions/1/content.mdx
+++ b/content/en/resources/events/building-and-linking-humanities-digital-spatial-infrastructures-for-research-in-the-nordic-countries/sessions/1/content.mdx
@@ -1,5 +1,5 @@
 Leif Isaksen talks the listener through the issues of making SDIs out of often messy humanities data. Special attention is paid to data management, i.e. reliability, bias vs. flexibility, scope, and perspective. Examples are fetched from i.a. Greek and Egyptian materials.
 
-<Video provider="youtube" id="https://www.youtube.com/embed/LmNVQwaxfNc">
+<Video provider="youtube" id="LmNVQwaxfNc">
   Presentation by Leif Isaksen
 </Video>

--- a/content/en/resources/events/building-and-linking-humanities-digital-spatial-infrastructures-for-research-in-the-nordic-countries/sessions/2/content.mdx
+++ b/content/en/resources/events/building-and-linking-humanities-digital-spatial-infrastructures-for-research-in-the-nordic-countries/sessions/2/content.mdx
@@ -1,5 +1,5 @@
 Ruth Mostern outlines humanities perspectives on place and place-making and how these can be operationalised in SRIs. The collaborative World Historical Gazetteer (WHG) project and its outputs serve as the main example. The talk focuses primarily on developing ontologies and vocabulary in a project setting e.g. Linked Places Format developed for the WHG.
 
-<Video provider="youtube" id="https://www.youtube.com/embed/RmoO-aJjDKw">
+<Video provider="youtube" id="RmoO-aJjDKw">
   Presentation by Ruth Mostern
 </Video>

--- a/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/1/content.mdx
+++ b/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/1/content.mdx
@@ -1,3 +1,3 @@
-<Video provider="youtube" id="https://www.youtube.com/embed/WaVgUurKUy8">
+<Video provider="youtube" id="WaVgUurKUy8">
   Presentation by Dr Georgios Artopoulos
 </Video>

--- a/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/2/content.mdx
+++ b/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/2/content.mdx
@@ -1,3 +1,3 @@
-<Video provider="youtube" id="https://www.youtube.com/embed/riZ4hiaZSqM">
+<Video provider="youtube" id="riZ4hiaZSqM">
   Presentation by Dr Carlos Smaniotto
 </Video>

--- a/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/3/content.mdx
+++ b/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/3/content.mdx
@@ -1,3 +1,3 @@
-<Video provider="youtube" id="https://www.youtube.com/embed/fQsykzk6i0Q">
+<Video provider="youtube" id="fQsykzk6i0Q">
   Presentation by Dr Gaia Redaelli
 </Video>

--- a/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/4/content.mdx
+++ b/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/4/content.mdx
@@ -4,10 +4,10 @@
 
 Data collection and co-creation was facilitated by the use of citizen volunteered geolocation software (readily available to the participants by the organisers), such as DEUSTO Tech [DARIAH](https://play.google.com/store/apps/details?id=mobility.deustotech.dariah_android) app. A separate mobile augmented-reality app, [WIKAR](http://wikar.co/), was used to facilitate a participatory project development processes. With this tool, workshop participants could visualize various project proposals directly projected in the real spaces subject of the project through their iOS and Android mobile devices.
 
-<Video provider="youtube" id="https://www.youtube.com/embed/HPZPO5Xp7hU">
+<Video provider="youtube" id="HPZPO5Xp7hU">
   Video recording of Wikar AR proposal visualization on site.
 </Video>
 
-<Video provider="youtube" id="https://www.youtube.com/embed/XQfSdYfbdkw">
+<Video provider="youtube" id="XQfSdYfbdkw">
   Presentation by Colter Wehmeier
 </Video>

--- a/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/5/content.mdx
+++ b/content/en/resources/events/use-of-ict-for-community-building-actions-towards-the-reactivation-of-urban-heritagescapes-in-south-european-cities/sessions/5/content.mdx
@@ -1,3 +1,3 @@
-<Video provider="youtube" id="https://www.youtube.com/embed/C2FlEPBTCkg">
+<Video provider="youtube" id="C2FlEPBTCkg">
   Presentation by Dr Alfonso Bahillo Martinez
 </Video>

--- a/lib/content/keystatic/components/video-card/index.tsx
+++ b/lib/content/keystatic/components/video-card/index.tsx
@@ -6,6 +6,7 @@ import { block } from "@keystatic/core/content-components";
 import { VideoIcon } from "lucide-react";
 
 import { VideoCardPreview } from "@/lib/content/keystatic/components/video-card/preview";
+import * as validation from "@/lib/content/keystatic/validation";
 import { videoProviders } from "@/lib/content/options";
 
 export const createVideoCard = createComponent((paths, _locale) => {
@@ -22,7 +23,7 @@ export const createVideoCard = createComponent((paths, _locale) => {
 				}),
 				id: fields.text({
 					label: "Video ID",
-					validation: { isRequired: true },
+					validation: { pattern: validation.videoId },
 				}),
 				startTime: fields.number({
 					label: "Start time",

--- a/lib/content/keystatic/components/video/index.tsx
+++ b/lib/content/keystatic/components/video/index.tsx
@@ -6,6 +6,7 @@ import { wrapper } from "@keystatic/core/content-components";
 import { VideoIcon } from "lucide-react";
 
 import { VideoPreview } from "@/lib/content/keystatic/components/video/preview";
+import * as validation from "@/lib/content/keystatic/validation";
 import { videoProviders } from "@/lib/content/options";
 
 export const createVideo = createComponent((_paths, _locale) => {
@@ -22,7 +23,7 @@ export const createVideo = createComponent((_paths, _locale) => {
 				}),
 				id: fields.text({
 					label: "Video ID",
-					validation: { isRequired: true },
+					validation: { pattern: validation.videoId },
 				}),
 				startTime: fields.number({
 					label: "Start time",

--- a/lib/content/keystatic/validation.ts
+++ b/lib/content/keystatic/validation.ts
@@ -22,3 +22,8 @@ export const urlSearchParamsOptional = {
 	regex: /^$|^\?.+/,
 	message: "Must include the leading '?' character.",
 };
+
+export const videoId = {
+	regex: /^[\w-]+$/,
+	message: "Must only include the 'id', not the full URL.",
+};


### PR DESCRIPTION
this adds a validation pattern to the `id` field for `Video` and `VideoCard` components, to ensure that only identifiers are passed, and not full urls like "https://youtube.com/embed/abcdef".

also fixes a couple of instances where content had invalid youtube ids.