### PR TITLE
feat: wrap main content in not-found boundary

### DIFF
--- a/app/(app)/(default)/not-found.tsx
+++ b/app/(app)/(default)/not-found.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
+import type { ReactNode } from "react";
+
+import { PageTitle } from "@/components/page-title";
+import { getMetadata } from "@/lib/i18n/metadata";
+
+export { viewport } from "@/app/_lib/viewport.config";
+
+export async function generateMetadata(): Promise<Metadata> {
+	const t = await getTranslations("NotFoundPage");
+	const meta = await getMetadata();
+
+	const metadata: Metadata = {
+		title: [t("meta.title"), meta.title].join(" | "),
+		/**
+		 * Automatically set by next.js.
+		 *
+		 * @see https://nextjs.org/docs/app/api-reference/functions/not-found
+		 */
+		// robots: {
+		// 	index: false,
+		// },
+	};
+
+	return metadata;
+}
+
+export default function NotFoundPage(): ReactNode {
+	const t = useTranslations("NotFoundPage");
+
+	return (
+		<div className="grid min-h-[calc(100dvh-100px)] place-content-center place-items-center">
+			<PageTitle>{t("title")}</PageTitle>
+		</div>
+	);
+}


### PR DESCRIPTION
the non-global not found page will only be used when the `(default)` route group matches (because that is where `not-found.tsx` lives). this means `/xxx` will show the global-not-found, but `/sources/xxx` will show the one wrapped with the default layout.

if we want this not-found page to be shown everywhere, we would need a catch-all route in the route group, or render the app shell in the global-not-found.

also, `dynamicParams = false` seems to always trigger the global-not-found.