### PR TITLE
fix: ensure opengraph image font is available in serverless function

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,9 @@ const config: Config = {
 		return Promise.resolve(headers);
 	},
 	output: env.BUILD_MODE,
+	outputFileTracingIncludes: {
+		"**/*": ["./public/assets/fonts/*.ttf"],
+	},
 	redirects() {
 		const redirects: Awaited<ReturnType<NonNullable<Config["redirects"]>>> = [
 			{


### PR DESCRIPTION
looks like next.js nft output file tracing does not include the `public/assets/fonts` folder even though it is accessed.