### PR TITLE
fix: only enable preview mode with valid branch and token

### DIFF
--- a/app/(app)/(default)/(index)/page.tsx
+++ b/app/(app)/(default)/(index)/page.tsx
@@ -1,7 +1,6 @@
 import { assert } from "@acdh-oeaw/lib";
 import { ChevronDownIcon, SearchIcon } from "lucide-react";
 import type { Metadata } from "next";
-import { draftMode } from "next/headers";
 import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 
@@ -19,6 +18,7 @@ import { SearchForm } from "@/components/search-form";
 import { client } from "@/lib/content/client";
 import type { IndexPage as IndexPageContent } from "@/lib/content/client/index-page";
 import { createGitHubClient } from "@/lib/content/github-client";
+import { getPreviewMode } from "@/lib/content/github-client/get-preview-mode";
 
 export function generateMetadata(): Metadata {
 	const metadata: Metadata = {
@@ -34,11 +34,12 @@ export function generateMetadata(): Metadata {
 }
 
 export default async function IndexPage(): Promise<ReactNode> {
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const page = draft.isEnabled
-		? await (await createGitHubClient()).singletons.indexPage.get()
-		: client.singletons.indexPage.get();
+	const page =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).singletons.indexPage.get()
+			: client.singletons.indexPage.get();
 
 	return (
 		<div className="mx-auto w-full max-w-screen-lg space-y-24 px-4 py-8 xs:px-8 xs:py-16 md:py-24">

--- a/app/(app)/(default)/curricula/[id]/page.tsx
+++ b/app/(app)/(default)/curricula/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { assert } from "@acdh-oeaw/lib";
 import type { Metadata } from "next";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
@@ -13,6 +12,7 @@ import { TagsList } from "@/components/tags-list";
 import { TranslationsList } from "@/components/translations-list";
 import { client } from "@/lib/content/client";
 import { createGitHubClient } from "@/lib/content/github-client";
+import { getPreviewMode } from "@/lib/content/github-client/get-preview-mode";
 import { pickRandom } from "@/lib/utils/pick-random";
 
 export const dynamicParams = false;
@@ -33,11 +33,12 @@ export async function generateMetadata(props: Readonly<CurriculumPageProps>): Pr
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const curriculum = draft.isEnabled
-		? await (await createGitHubClient()).collections.curricula.get(id)
-		: client.collections.curricula.get(id);
+	const curriculum =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.curricula.get(id)
+			: client.collections.curricula.get(id);
 
 	if (curriculum == null) {
 		notFound();
@@ -63,11 +64,12 @@ export default async function CurriculumPage(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const curriculum = draft.isEnabled
-		? await (await createGitHubClient()).collections.curricula.get(id)
-		: client.collections.curricula.get(id);
+	const curriculum =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.curricula.get(id)
+			: client.collections.curricula.get(id);
 
 	if (curriculum == null) {
 		notFound();

--- a/app/(app)/(default)/documentation/[id]/page.tsx
+++ b/app/(app)/(default)/documentation/[id]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Fragment, type ReactNode } from "react";
@@ -11,6 +10,7 @@ import { PageTitle } from "@/components/page-title";
 import { TableOfContents } from "@/components/table-of-contents";
 import { client } from "@/lib/content/client";
 import { createGitHubClient } from "@/lib/content/github-client";
+import { getPreviewMode } from "@/lib/content/github-client/get-preview-mode";
 
 export const dynamicParams = false;
 
@@ -32,11 +32,12 @@ export async function generateMetadata(props: Readonly<DocumentationPageProps>):
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const page = draft.isEnabled
-		? await (await createGitHubClient()).collections.documentation.get(id)
-		: client.collections.documentation.get(id);
+	const page =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.documentation.get(id)
+			: client.collections.documentation.get(id);
 
 	if (page == null) {
 		notFound();
@@ -61,11 +62,12 @@ export default async function DocumentationPage(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const page = draft.isEnabled
-		? await (await createGitHubClient()).collections.documentation.get(id)
-		: client.collections.documentation.get(id);
+	const page =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.documentation.get(id)
+			: client.collections.documentation.get(id);
 
 	if (page == null) {
 		notFound();

--- a/app/(app)/(default)/layout.tsx
+++ b/app/(app)/(default)/layout.tsx
@@ -3,8 +3,8 @@ import { Fragment, type ReactNode, Suspense } from "react";
 
 import { DefaultFooter } from "@/app/(app)/(default)/_components/default-footer";
 import { DefaultHeader } from "@/app/(app)/(default)/_components/default-header";
-import { DraftModeBanner } from "@/components/draft-mode-banner";
 import { Main } from "@/components/main";
+import { PreviewModeBanner } from "@/components/preview-mode-banner";
 import { SkipLink } from "@/components/skip-link";
 
 const mainContentId = "main-content";
@@ -21,7 +21,7 @@ export default function DefaultLayout(props: Readonly<DefaultLayoutProps>): Reac
 			<SkipLink href={`#${mainContentId}`}>{t("skip-link")}</SkipLink>
 
 			<Suspense>
-				<DraftModeBanner />
+				<PreviewModeBanner />
 			</Suspense>
 
 			<div className="relative isolate grid min-h-full grid-rows-[auto_1fr_auto]">

--- a/app/(app)/(default)/resources/events/[id]/page.tsx
+++ b/app/(app)/(default)/resources/events/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { assert, createUrl } from "@acdh-oeaw/lib";
 import type { Metadata } from "next";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { getFormatter, getTranslations } from "next-intl/server";
 import { Fragment, type ReactNode } from "react";
@@ -24,6 +23,7 @@ import { TagsList } from "@/components/tags-list";
 import { TranslationsList } from "@/components/translations-list";
 import { client } from "@/lib/content/client";
 import { createGitHubClient } from "@/lib/content/github-client";
+import { getPreviewMode } from "@/lib/content/github-client/get-preview-mode";
 import { createResourceMetadata } from "@/lib/content/utils/create-resource-metadata";
 import { getMetadata } from "@/lib/i18n/metadata";
 import { createFullUrl } from "@/lib/navigation/create-full-url";
@@ -51,11 +51,12 @@ export async function generateMetadata(props: Readonly<EventResourcePageProps>):
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const resource = draft.isEnabled
-		? await (await createGitHubClient()).collections.resourcesEvents.get(id)
-		: client.collections.resourcesEvents.get(id);
+	const resource =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.resourcesEvents.get(id)
+			: client.collections.resourcesEvents.get(id);
 
 	if (resource == null) {
 		notFound();
@@ -113,11 +114,12 @@ export default async function EventResourcePage(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const resource = draft.isEnabled
-		? await (await createGitHubClient()).collections.resourcesEvents.get(id)
-		: client.collections.resourcesEvents.get(id);
+	const resource =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.resourcesEvents.get(id)
+			: client.collections.resourcesEvents.get(id);
 
 	if (resource == null) {
 		notFound();

--- a/app/(app)/(default)/resources/external/[id]/page.tsx
+++ b/app/(app)/(default)/resources/external/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { assert } from "@acdh-oeaw/lib";
 import type { Metadata } from "next";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Fragment, type ReactNode } from "react";
@@ -18,6 +17,7 @@ import { TagsList } from "@/components/tags-list";
 import { TranslationsList } from "@/components/translations-list";
 import { client } from "@/lib/content/client";
 import { createGitHubClient } from "@/lib/content/github-client";
+import { getPreviewMode } from "@/lib/content/github-client/get-preview-mode";
 import { createResourceMetadata } from "@/lib/content/utils/create-resource-metadata";
 import { getMetadata } from "@/lib/i18n/metadata";
 import { createFullUrl } from "@/lib/navigation/create-full-url";
@@ -47,11 +47,12 @@ export async function generateMetadata(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const resource = draft.isEnabled
-		? await (await createGitHubClient()).collections.resourcesExternal.get(id)
-		: client.collections.resourcesExternal.get(id);
+	const resource =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.resourcesExternal.get(id)
+			: client.collections.resourcesExternal.get(id);
 
 	if (resource == null) {
 		notFound();
@@ -107,11 +108,12 @@ export default async function ExternalResourcePage(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const resource = draft.isEnabled
-		? await (await createGitHubClient()).collections.resourcesExternal.get(id)
-		: client.collections.resourcesExternal.get(id);
+	const resource =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.resourcesExternal.get(id)
+			: client.collections.resourcesExternal.get(id);
 
 	if (resource == null) {
 		notFound();

--- a/app/(app)/(default)/resources/hosted/[id]/page.tsx
+++ b/app/(app)/(default)/resources/hosted/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { assert } from "@acdh-oeaw/lib";
 import type { Metadata } from "next";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Fragment, type ReactNode } from "react";
@@ -18,6 +17,7 @@ import { TagsList } from "@/components/tags-list";
 import { TranslationsList } from "@/components/translations-list";
 import { client } from "@/lib/content/client";
 import { createGitHubClient } from "@/lib/content/github-client";
+import { getPreviewMode } from "@/lib/content/github-client/get-preview-mode";
 import { createResourceMetadata } from "@/lib/content/utils/create-resource-metadata";
 import { getMetadata } from "@/lib/i18n/metadata";
 import { createFullUrl } from "@/lib/navigation/create-full-url";
@@ -47,11 +47,12 @@ export async function generateMetadata(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const resource = draft.isEnabled
-		? await (await createGitHubClient()).collections.resourcesHosted.get(id)
-		: client.collections.resourcesHosted.get(id);
+	const resource =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.resourcesHosted.get(id)
+			: client.collections.resourcesHosted.get(id);
 
 	if (resource == null) {
 		notFound();
@@ -107,11 +108,12 @@ export default async function HostedResourcePage(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const resource = draft.isEnabled
-		? await (await createGitHubClient()).collections.resourcesHosted.get(id)
-		: client.collections.resourcesHosted.get(id);
+	const resource =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.resourcesHosted.get(id)
+			: client.collections.resourcesHosted.get(id);
 
 	if (resource == null) {
 		notFound();

--- a/app/(app)/(default)/resources/pathfinders/[id]/page.tsx
+++ b/app/(app)/(default)/resources/pathfinders/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { assert } from "@acdh-oeaw/lib";
 import type { Metadata } from "next";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Fragment, type ReactNode } from "react";
@@ -18,6 +17,7 @@ import { TagsList } from "@/components/tags-list";
 import { TranslationsList } from "@/components/translations-list";
 import { client } from "@/lib/content/client";
 import { createGitHubClient } from "@/lib/content/github-client";
+import { getPreviewMode } from "@/lib/content/github-client/get-preview-mode";
 import { createResourceMetadata } from "@/lib/content/utils/create-resource-metadata";
 import { getMetadata } from "@/lib/i18n/metadata";
 import { createFullUrl } from "@/lib/navigation/create-full-url";
@@ -47,11 +47,12 @@ export async function generateMetadata(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const resource = draft.isEnabled
-		? await (await createGitHubClient()).collections.resourcesPathfinders.get(id)
-		: client.collections.resourcesPathfinders.get(id);
+	const resource =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.resourcesPathfinders.get(id)
+			: client.collections.resourcesPathfinders.get(id);
 
 	if (resource == null) {
 		notFound();
@@ -107,11 +108,12 @@ export default async function PathfinderResourcePage(
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const resource = draft.isEnabled
-		? await (await createGitHubClient()).collections.resourcesPathfinders.get(id)
-		: client.collections.resourcesPathfinders.get(id);
+	const resource =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.resourcesPathfinders.get(id)
+			: client.collections.resourcesPathfinders.get(id);
 
 	if (resource == null) {
 		notFound();

--- a/app/(app)/(default)/sources/[id]/page.tsx
+++ b/app/(app)/(default)/sources/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { assert } from "@acdh-oeaw/lib";
 import type { Metadata } from "next";
-import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
@@ -10,6 +9,7 @@ import { PageTitle } from "@/components/page-title";
 import { ResourcesGrid } from "@/components/resources-grid";
 import { client } from "@/lib/content/client";
 import { createGitHubClient } from "@/lib/content/github-client";
+import { getPreviewMode } from "@/lib/content/github-client/get-preview-mode";
 
 export const dynamicParams = false;
 
@@ -29,11 +29,12 @@ export async function generateMetadata(props: Readonly<SourcePageProps>): Promis
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const source = draft.isEnabled
-		? await (await createGitHubClient()).collections.sources.get(id)
-		: client.collections.sources.get(id);
+	const source =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.sources.get(id)
+			: client.collections.sources.get(id);
 
 	if (source == null) {
 		notFound();
@@ -56,11 +57,12 @@ export default async function SourcePage(props: Readonly<SourcePageProps>): Prom
 	const { id: _id } = await params;
 	const id = decodeURIComponent(_id);
 
-	const draft = await draftMode();
+	const preview = await getPreviewMode();
 
-	const source = draft.isEnabled
-		? await (await createGitHubClient()).collections.sources.get(id)
-		: client.collections.sources.get(id);
+	const source =
+		preview.status === "enabled"
+			? await createGitHubClient(preview).collections.sources.get(id)
+			: client.collections.sources.get(id);
 
 	if (source == null) {
 		notFound();

--- a/components/preview-mode-banner.tsx
+++ b/components/preview-mode-banner.tsx
@@ -4,8 +4,8 @@ import type { ReactNode } from "react";
 
 import { Link } from "@/components/link";
 
-export async function DraftModeBanner(): Promise<ReactNode> {
-	const t = await getTranslations("DraftModeBanner");
+export async function PreviewModeBanner(): Promise<ReactNode> {
+	const t = await getTranslations("PreviewModeBanner");
 
 	const draft = await draftMode();
 	const isDraftModeEnabled = draft.isEnabled;
@@ -17,10 +17,12 @@ export async function DraftModeBanner(): Promise<ReactNode> {
 	const cookieStore = await cookies();
 
 	const branch = cookieStore.get("ks-branch")?.value;
+	const token = cookieStore.get("keystatic-gh-access-token")?.value;
 
 	return (
 		<aside className="fixed inset-x-0 bottom-0 z-10 flex justify-between bg-amber-700 px-4 py-2 font-medium text-white">
-			{t("enabled")} ({branch != null ? t("branch", { branch }) : t("invalid-branch")})
+			{t("enabled")} (
+			{branch != null && token != null ? t("branch", { branch }) : t("invalid-branch")})
 			<Link
 				className="underline underline-offset-4 hover:no-underline"
 				href="/api/preview/disable"

--- a/lib/content/github-client/get-preview-mode.ts
+++ b/lib/content/github-client/get-preview-mode.ts
@@ -1,0 +1,49 @@
+import { cookies, draftMode } from "next/headers";
+
+import { env } from "@/config/env.config";
+
+type PreviewMode =
+	| {
+			status: "enabled";
+			owner: string;
+			repo: string;
+			branch: string;
+			token: string;
+	  }
+	| {
+			status: "disabled";
+	  };
+
+export async function getPreviewMode(): Promise<PreviewMode> {
+	const draft = await draftMode();
+	const isDraftModeEnabled = draft.isEnabled;
+
+	if (isDraftModeEnabled) {
+		const owner = env.NEXT_PUBLIC_KEYSTATIC_GITHUB_REPO_OWNER;
+		const repo = env.NEXT_PUBLIC_KEYSTATIC_GITHUB_REPO_NAME;
+
+		if (owner != null && repo != null) {
+			const cookieStore = await cookies();
+
+			const branch = cookieStore.get("ks-branch")?.value;
+			const token = cookieStore.get("keystatic-gh-access-token")?.value;
+
+			if (branch != null && token != null) {
+				return {
+					status: "enabled",
+					owner,
+					repo,
+					branch,
+					token,
+				};
+			}
+		}
+
+		/** This seems to work even though it is not called in a route handler. */
+		draft.disable();
+	}
+
+	return {
+		status: "disabled",
+	};
+}

--- a/lib/content/github-client/index.ts
+++ b/lib/content/github-client/index.ts
@@ -2,10 +2,8 @@ import "server-only";
 
 import { assert, createUrl } from "@acdh-oeaw/lib";
 import { createGitHubReader } from "@keystatic/core/reader/github";
-import { cookies } from "next/headers";
 import { cache } from "react";
 
-import { env } from "@/config/env.config";
 import { client } from "@/lib/content/client";
 import type { Curriculum } from "@/lib/content/client/curricula";
 import type { Documentation } from "@/lib/content/client/documentation";
@@ -72,20 +70,17 @@ const createEvaluateOptions = (baseUrl: string) => {
 	} satisfies EvaluateOptions;
 };
 
-export const createGitHubClient = cache(async function createGitHubClient() {
-	const owner = env.NEXT_PUBLIC_KEYSTATIC_GITHUB_REPO_OWNER;
-	const repo = env.NEXT_PUBLIC_KEYSTATIC_GITHUB_REPO_NAME;
-
-	assert(owner != null && repo != null, "Missing github repository config.");
-
-	const cookieStore = await cookies();
-
-	const branch = cookieStore.get("ks-branch")?.value;
-	const token = cookieStore.get("keystatic-gh-access-token")?.value;
-
-	assert(branch, "Missing github branch.");
-	assert(token, "Missing github access token.");
-
+export const createGitHubClient = cache(function createGitHubClient({
+	owner,
+	repo,
+	branch,
+	token,
+}: {
+	owner: string;
+	repo: string;
+	branch: string;
+	token: string;
+}) {
 	const reader = createGitHubReader(config, {
 		repo: `${owner}/${repo}`,
 		ref: branch,

--- a/messages/en.json
+++ b/messages/en.json
@@ -123,12 +123,6 @@
 		"table-of-contents": "Table of contents",
 		"toggle-table-of-contents": "Toggle table of contents"
 	},
-	"DraftModeBanner": {
-		"branch": "Branch: {branch}",
-		"disable": "Disable",
-		"enabled": "Draft mode enabled",
-		"invalid-branch": "Branch invalid or missing"
-	},
 	"ErrorPage": {
 		"meta": {
 			"title": "Error"
@@ -234,6 +228,12 @@
 	"PreviewCard": {
 		"authors": "Authors",
 		"read-more": "Read more"
+	},
+	"PreviewModeBanner": {
+		"branch": "Branch: {branch}",
+		"disable": "Disable",
+		"enabled": "Preview mode enabled",
+		"invalid-branch": "Branch invalid or missing"
 	},
 	"RelatedCurriculaList": {
 		"label": "Related curricula"


### PR DESCRIPTION
when draft mode is enabled (i.e. we have a `__prerender_bypass` cookie) but don't have a valid branch name or token (read from cookies), we should not enable preview mode. we still want to render the orange banner though, so a user can click Disable (and so it is not confusing when a 404 page is displayed because a newly created resources does not exist in the production build). we also call `draftMode.disable` in that case, which does the same as clicking Disable, and surprisingly seems to work even though it is not called in a route handler.