### PR TITLE
feat: allow floating images (figures)

### DIFF
--- a/components/content/figure.tsx
+++ b/components/content/figure.tsx
@@ -18,23 +18,27 @@ interface FigureProps {
 
 export function Figure(props: Readonly<FigureProps>): ReactNode {
 	const { alignment = "stretch", alt = "", children, height, src, width } = props;
+	const figureWidths = {
+		"right-one-fourth": "sm:w-1/4",
+		"right-one-third": "sm:w-1/3",
+		"right-one-half": "sm:w-1/2",
+		"right-two-thirds": "sm:w-2/3",
+		center: "",
+		stretch: "",
+	};
 
 	return (
 		<figure
 			className={cn(
 				"flex flex-col",
 				alignment === "center" ? "justify-center" : undefined,
-				alignment === "left"
-					? "inline-block sm:float-left sm:my-0 sm:me-4"
-					: alignment === "right"
-						? "inline-block sm:float-right sm:my-0 sm:ms-4"
-						: undefined,
+				alignment.includes("right")
+					? `inline-block sm:float-right sm:my-0 sm:ms-4 ${figureWidths[alignment]}`
+					: undefined,
 			)}
 		>
 			<Image alt={alt} height={height} src={src} width={width} />
-			<figcaption
-				className={cn(["left", "right"].includes(alignment) ? "sm:contain-inline-size" : undefined)}
-			>
+			<figcaption className={alignment.includes("right") ? "sm:contain-inline-size" : undefined}>
 				{children}
 			</figcaption>
 		</figure>

--- a/components/content/figure.tsx
+++ b/components/content/figure.tsx
@@ -20,9 +20,23 @@ export function Figure(props: Readonly<FigureProps>): ReactNode {
 	const { alignment = "stretch", alt = "", children, height, src, width } = props;
 
 	return (
-		<figure className={cn("flex flex-col", alignment === "center" ? "justify-center" : undefined)}>
+		<figure
+			className={cn(
+				"flex flex-col",
+				alignment === "center" ? "justify-center" : undefined,
+				alignment === "left"
+					? "inline-block sm:float-left sm:my-0 sm:me-4"
+					: alignment === "right"
+						? "inline-block sm:float-right sm:my-0 sm:ms-4"
+						: undefined,
+			)}
+		>
 			<Image alt={alt} height={height} src={src} width={width} />
-			<figcaption>{children}</figcaption>
+			<figcaption
+				className={cn(["left", "right"].includes(alignment) ? "sm:contain-inline-size" : undefined)}
+			>
+				{children}
+			</figcaption>
 		</figure>
 	);
 }

--- a/content/en/resources/hosted/capturing-modeling-and-transforming-lexical-data-an-introduction/index.mdx
+++ b/content/en/resources/hosted/capturing-modeling-and-transforming-lexical-data-an-introduction/index.mdx
@@ -39,7 +39,7 @@ The Library of Alexandria -- one of the wonders of the Ancient World, was founde
 
 While the destruction of the Library of Alexandria is to this day seen as a symbol of tragic loss of knowledge and culture, it is by no means a singular incident in history. Wars, civil unrest and natural disasters, but sometimes also mere accidents, continue to destroy and damage the human record. A 2004 fire in the Duchess Ana Amalia Library in Weimer destroyed some 50,000 volumes of which 12,500 are considered irreplaceable.
 
-<Figure src="/assets/content/assets/en/resources/hosted/capturing-modeling-and-transforming-lexical-data-an-introduction/n-nw9-ti-3l.jpg">
+<Figure src="/assets/content/assets/en/resources/hosted/capturing-modeling-and-transforming-lexical-data-an-introduction/n-nw9-ti-3l.jpg" alignment="right-one-half">
   [E. Herzel](https://commons.wikimedia.org/wiki/File%3ABrand_Anna_Amalia_22.30Uhr.JPG). CC-BY-SA-3.0
 </Figure>
 
@@ -455,7 +455,7 @@ A dictionary is a kind of text. It's a specific kind of text, but it is text non
 
 This is, in fact, something that can be said of most texts. Whether we draw our source of inspiration from Russian *matryoshkas* or Chinese boxes, we all know how structural 'nesting' works in books: a book may consist of chapters, a chapter may consist of sections, each section may contain a separate title and several paragraphs. Inside paragraphs we may find, for instance, lists etc. These content objects fit neatly into one another, from the smallest (a letter or a word) to the largest (a book or monograph), with a myriad of other nested units in between (sentences, paragraphs etc).
 
-<Figure src="/assets/content/assets/en/resources/hosted/capturing-modeling-and-transforming-lexical-data-an-introduction/kz6-bam-8m.jpg">
+<Figure src="/assets/content/assets/en/resources/hosted/capturing-modeling-and-transforming-lexical-data-an-introduction/kz6-bam-8m.jpg" alignment="right-one-half">
   Help! I'm trapped inside a text. CC BY 3.0 J. Ronald Lee
 </Figure>
 
@@ -472,8 +472,7 @@ Unlike some of our colleagues who are eternally damned to ponder the overlapping
 ### Textual markup
 
 For centuries textual scholars have made choices in disambiguating marks on page, in deciding how to format text as it migrates from one form to another, to show changes in a work over time, be they authorial (i.e. created by the author of the work) or by other agents (editors, relations, friends, or unknown scribes).
-
-![](/assets/content/assets/en/resources/hosted/capturing-modeling-and-transforming-lexical-data-an-introduction/bg-yaa-8o.jpg)
+<Figure src="/assets/content/assets/en/resources/hosted/capturing-modeling-and-transforming-lexical-data-an-introduction/bg-yaa-8o.jpg" alignment="right-one-third"/>
 
 In the eighteenth and nineteenth centuries as print became the de facto medium in which to transmit en masse the textual record, be it for pleasure (the rise of the novel), for religious purposes (the reproduction of sacred texts and commentary), for or political purposes (as a way of defining the new nation states and their peoples by their literary inheritance), so too the need arose for individuals to adjudicate on the version of the text to be published, what introductory material might be included, or which texts should be group together and published as collections.
 

--- a/content/en/resources/hosted/introduction-to-dictionaries/index.mdx
+++ b/content/en/resources/hosted/introduction-to-dictionaries/index.mdx
@@ -140,7 +140,7 @@ The oldest dictionaries that we know of — those produced in the Middle East, A
 1. that words which are assumed to be known to the user can be used to describe those that are not; and
 2. that words to be explained need to be arranged somehow in order for the user to be able to locate them.nigram
 
-<Figure src="/assets/content/assets/en/resources/hosted/introduction-to-dictionaries/h-vla9hu.jpg" alignment="right">
+<Figure src="/assets/content/assets/en/resources/hosted/introduction-to-dictionaries/h-vla9hu.jpg" alignment="right-one-third">
   16th tablet of the Urra=hubullu lexical series, Louvre Museum. [CC BY 2.5](https://creativecommons.org/licenses/by/2.5)
 </Figure>
 

--- a/content/en/resources/hosted/introduction-to-dictionaries/index.mdx
+++ b/content/en/resources/hosted/introduction-to-dictionaries/index.mdx
@@ -140,7 +140,7 @@ The oldest dictionaries that we know of — those produced in the Middle East, A
 1. that words which are assumed to be known to the user can be used to describe those that are not; and
 2. that words to be explained need to be arranged somehow in order for the user to be able to locate them.nigram
 
-<Figure src="/assets/content/assets/en/resources/hosted/introduction-to-dictionaries/h-vla9hu.jpg">
+<Figure src="/assets/content/assets/en/resources/hosted/introduction-to-dictionaries/h-vla9hu.jpg" alignment="right">
   16th tablet of the Urra=hubullu lexical series, Louvre Museum. [CC BY 2.5](https://creativecommons.org/licenses/by/2.5)
 </Figure>
 

--- a/content/en/resources/hosted/transforming-lexical-data-xslt-for-dictionary-nerds/index.mdx
+++ b/content/en/resources/hosted/transforming-lexical-data-xslt-for-dictionary-nerds/index.mdx
@@ -65,7 +65,7 @@ This really bears repeating: you can't do XSLT without XPath. This is because XS
 
 XSLT was created specifically for trasnforming XML. It's data-centric, purpose-built and quite clever: unlike general programming languages, which can be used to create all sorts of different pieces of software, XSLT does one thing, and it does it well. (Calm down, XSLT afficionados! XSLT *is* very powerful and can do many things, but we're trying to make a point here.)
 
-<Figure src="/assets/content/assets/en/resources/hosted/transforming-lexical-data-xslt-for-dictionary-nerds/cat.jpg">
+<Figure src="/assets/content/assets/en/resources/hosted/transforming-lexical-data-xslt-for-dictionary-nerds/cat.jpg" alignment="right-one-half">
   Like a lazy cat, XSLT will always go for the absolute minimum! (Photo by [@ludemeula](https://unsplash.com/photos/9UUoGaaHtNE))
 </Figure>
 

--- a/lib/content/keystatic/components/figure/preview.tsx
+++ b/lib/content/keystatic/components/figure/preview.tsx
@@ -19,7 +19,17 @@ export function FigurePreview(props: Readonly<FigurePreviewProps>): ReactNode {
 	const url = useObjectUrl(src);
 
 	return (
-		<figure className={cn("grid gap-y-2", alignment === "center" ? "justify-center" : undefined)}>
+		<figure
+			className={cn(
+				"grid gap-y-2",
+				alignment === "center" ? "justify-center" : undefined,
+				alignment === "left"
+					? "inline-block sm:float-left sm:my-0 sm:me-4"
+					: alignment === "right"
+						? "inline-block sm:float-right sm:my-0 sm:ms-4"
+						: undefined,
+			)}
+		>
 			<NotEditable>
 				{url != null ? (
 					// eslint-disable-next-line @next/next/no-img-element
@@ -30,7 +40,14 @@ export function FigurePreview(props: Readonly<FigurePreviewProps>): ReactNode {
 					/>
 				) : null}
 			</NotEditable>
-			<figcaption className="text-sm">{children}</figcaption>
+			<figcaption
+				className={cn(
+					"text-sm",
+					["left", "right"].includes(alignment) ? "sm:contain-inline-size" : undefined,
+				)}
+			>
+				{children}
+			</figcaption>
 		</figure>
 	);
 }

--- a/lib/content/keystatic/components/figure/preview.tsx
+++ b/lib/content/keystatic/components/figure/preview.tsx
@@ -23,11 +23,7 @@ export function FigurePreview(props: Readonly<FigurePreviewProps>): ReactNode {
 			className={cn(
 				"grid gap-y-2",
 				alignment === "center" ? "justify-center" : undefined,
-				alignment === "left"
-					? "inline-block sm:float-left sm:my-0 sm:me-4"
-					: alignment === "right"
-						? "inline-block sm:float-right sm:my-0 sm:ms-4"
-						: undefined,
+				alignment.includes("right") ? "justify-end" : undefined,
 			)}
 		>
 			<NotEditable>
@@ -40,14 +36,7 @@ export function FigurePreview(props: Readonly<FigurePreviewProps>): ReactNode {
 					/>
 				) : null}
 			</NotEditable>
-			<figcaption
-				className={cn(
-					"text-sm",
-					["left", "right"].includes(alignment) ? "sm:contain-inline-size" : undefined,
-				)}
-			>
-				{children}
-			</figcaption>
+			<figcaption>{children}</figcaption>
 		</figure>
 	);
 }

--- a/lib/content/options.ts
+++ b/lib/content/options.ts
@@ -34,6 +34,8 @@ export type ContentType = (typeof contentTypes)[number]["value"];
 
 export const figureAlignments = [
 	{ label: "Center", value: "center" },
+	{ label: "Left", value: "left" },
+	{ label: "Right", value: "right" },
 	{ label: "Stretch", value: "stretch" },
 ] as const;
 

--- a/lib/content/options.ts
+++ b/lib/content/options.ts
@@ -34,8 +34,10 @@ export type ContentType = (typeof contentTypes)[number]["value"];
 
 export const figureAlignments = [
 	{ label: "Center", value: "center" },
-	{ label: "Left", value: "left" },
-	{ label: "Right", value: "right" },
+	{ label: "Right, 1/4", value: "right-one-fourth" },
+	{ label: "Right, 1/3", value: "right-one-third" },
+	{ label: "Right, 1/2", value: "right-one-half" },
+	{ label: "Right, 2/3", value: "right-two-thirds" },
 	{ label: "Stretch", value: "stretch" },
 ] as const;
 


### PR DESCRIPTION
this allows images to float to the right, with text wrapping around the image. we support image widths of 1/2, 1/3, 1/4 and 2/3 of the content column width. for viewport widths smaller than 640px we avoid floating images.

closes #1552