### PR TITLE
feat: add publication year filter to v2 api routes

### DIFF
--- a/app/(app)/api/v2/metadata/curricula/route.ts
+++ b/app/(app)/api/v2/metadata/curricula/route.ts
@@ -19,6 +19,9 @@ const searchFiltersSchema = v.object({
 		v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(0)),
 		"0",
 	),
+	publicationYear: v.nullish(
+		v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(0)),
+	),
 });
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -29,11 +32,21 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 			limit: searchParams.get("limit"),
 			offset: searchParams.get("offset"),
 			kind: searchParams.getAll("kind"),
+			publicationYear: searchParams.get("publication-year"),
 		});
 
+		const _items = curricula;
+
+		const items =
+			filters.publicationYear != null
+				? _items.filter((item) => {
+						return new Date(item["publication-date"]).getUTCFullYear() === filters.publicationYear;
+					})
+				: _items;
+
 		const { limit, offset } = filters;
-		const total = curricula.length;
-		const page = curricula.slice(offset, offset + limit);
+		const total = items.length;
+		const page = items.slice(offset, offset + limit);
 
 		return NextResponse.json({ total, limit, offset, items: page });
 	} catch (error) {


### PR DESCRIPTION
this adds a `publication-year` search param to the v2 api routes, which filters results by publication year.

example:

https://campus.dariah.eu/api/v2/metadata/resources?publication-year=2025