### PR TITLE
ci: run e2e tests on preview branches

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -11,6 +11,8 @@
 NEXT_PUBLIC_APP_BASE_URL="http://localhost:3000"
 # used to link to cms on preview branch deployments
 NEXT_PUBLIC_APP_PRODUCTION_BASE_URL="http://localhost:3000"
+# imprint service
+NEXT_PUBLIC_REDMINE_ID="16225"
 # web crawlers
 NEXT_PUBLIC_BOTS="disabled"
 # validate environment variables

--- a/.env.local.example
+++ b/.env.local.example
@@ -11,8 +11,6 @@
 NEXT_PUBLIC_APP_BASE_URL="http://localhost:3000"
 # used to link to cms on preview branch deployments
 NEXT_PUBLIC_APP_PRODUCTION_BASE_URL="http://localhost:3000"
-# imprint service
-NEXT_PUBLIC_REDMINE_ID="16225"
 # web crawlers
 NEXT_PUBLIC_BOTS="disabled"
 # validate environment variables

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -91,7 +91,7 @@ jobs:
           path: "${{ github.workspace }}/.next/cache"
           key: "${{ matrix.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}"
 
-      - name: Start typesense server
+      - name: Start typesense server and populate search index
         run: |
           touch .env.local
           pnpm run dev:typesense:up
@@ -110,7 +110,7 @@ jobs:
       - name: Run e2e tests
         run: pnpm run test:e2e
 
-      - name: Start typesense server
+      - name: Stop typesense server
         run: pnpm run dev:typesense:down
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,109 @@
+name: Validate
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}-validate"
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches-ignore:
+      - main
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+
+    env:
+      NEXT_PUBLIC_APP_BASE_URL: "http://localhost:3000"
+      NEXT_PUBLIC_APP_PRODUCTION_BASE_URL: "http://localhost:3000"
+      NEXT_PUBLIC_TYPESENSE_COLLECTION: "dariah-campus"
+      NEXT_PUBLIC_TYPESENSE_HOST: "localhost"
+      NEXT_PUBLIC_TYPESENSE_PORT: "8108"
+      NEXT_PUBLIC_TYPESENSE_PROTOCOL: "http"
+      TYPESENSE_ADMIN_API_KEY: "xyz"
+
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [22.x]
+        os: [ubuntu-24.04]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Format
+        run: pnpm run format:check
+
+      - name: Lint
+        run: pnpm run lint:check
+
+      - name: Typecheck
+        run: pnpm run types:check
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Get playwright version
+        run: |
+          PLAYWRIGHT_VERSION=$(pnpm ls @playwright/test --json | jq --raw-output '.[0].devDependencies["@playwright/test"].version')
+          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
+
+      - name: Cache playwright browsers
+        uses: actions/cache@v4
+        id: cache-playwright-browsers
+        with:
+          path: "~/.cache/ms-playwright"
+          key: "${{ matrix.os }}-playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}"
+
+      - name: Install playwright browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps
+      - name: Install playwright browsers (operating system dependencies)
+        if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps
+
+      # https://nextjs.org/docs/pages/building-your-application/deploying/ci-build-caching#github-actions
+      - name: Cache Next.js build output
+        uses: actions/cache@v4
+        with:
+          path: "${{ github.workspace }}/.next/cache"
+          key: "${{ matrix.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}"
+
+      - name: Start typesense server
+        run: |
+          touch .env.local
+          pnpm run dev:typesense:up
+          pnpm run typesense:collection:create
+          pnpm run typesense:collection:seed
+          NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY=$(pnpm run typesense:api-key:create | awk -F'"' '{print $2}') >> $GITHUB_ENV
+
+      - name: Build app
+        run: pnpm run build
+
+      - name: Run e2e tests
+        run: pnpm run test:e2e
+
+      - name: Start typesense server
+        run: pnpm run dev:typesense:down
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,12 +6,13 @@ concurrency:
 
 on:
   pull_request:
-    branches-ignore:
+    branches:
       - main
 
 jobs:
   validate:
     name: Validate
+    if: ${{ !startsWith(github.head_ref, 'content/') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
@@ -48,6 +49,12 @@ jobs:
 
       - name: Format
         run: pnpm run format:check
+
+      - name: Transform content
+        run: pnpm run content:build
+
+      - name: Generate metadata dump
+        run: pnpm run generate:metadata-dump
 
       - name: Lint
         run: pnpm run lint:check
@@ -88,9 +95,14 @@ jobs:
         run: |
           touch .env.local
           pnpm run dev:typesense:up
+          echo "Waiting for Typesense to be ready..."
+          until curl -s -o /dev/null -w "%{http_code}" -H "X-TYPESENSE-API-KEY: $TYPESENSE-API-KEY" http://localhost:8108/health | grep -q 200; do
+            echo -n "."
+            sleep 1
+          done
           pnpm run typesense:collection:create
           pnpm run typesense:collection:seed
-          NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY=$(pnpm run typesense:api-key:create | awk -F'"' '{print $2}') >> $GITHUB_ENV
+          echo NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY=$(pnpm run typesense:api-key:create | awk -F'"' '{print $2}') >> $GITHUB_ENV
 
       - name: Build app
         run: pnpm run build

--- a/config/env.config.ts
+++ b/config/env.config.ts
@@ -73,13 +73,6 @@ const result = createEnv({
 				NEXT_PUBLIC_MATOMO_ID: v.optional(
 					v.pipe(v.string(), v.transform(Number), v.number(), v.integer(), v.minValue(1)),
 				),
-				NEXT_PUBLIC_REDMINE_ID: v.pipe(
-					v.string(),
-					v.transform(Number),
-					v.number(),
-					v.integer(),
-					v.minValue(1),
-				),
 				NEXT_PUBLIC_TYPESENSE_COLLECTION: v.pipe(v.string(), v.nonEmpty()),
 				NEXT_PUBLIC_TYPESENSE_HOST: v.pipe(v.string(), v.nonEmpty()),
 				NEXT_PUBLIC_TYPESENSE_PORT: v.pipe(
@@ -127,7 +120,6 @@ const result = createEnv({
 		NEXT_PUBLIC_KEYSTATIC_MODE: process.env.NEXT_PUBLIC_KEYSTATIC_MODE,
 		NEXT_PUBLIC_MATOMO_BASE_URL: process.env.NEXT_PUBLIC_MATOMO_BASE_URL,
 		NEXT_PUBLIC_MATOMO_ID: process.env.NEXT_PUBLIC_MATOMO_ID,
-		NEXT_PUBLIC_REDMINE_ID: process.env.NEXT_PUBLIC_REDMINE_ID,
 		NEXT_PUBLIC_TYPESENSE_COLLECTION: process.env.NEXT_PUBLIC_TYPESENSE_COLLECTION,
 		NEXT_PUBLIC_TYPESENSE_HOST: process.env.NEXT_PUBLIC_TYPESENSE_HOST,
 		NEXT_PUBLIC_TYPESENSE_PORT: process.env.NEXT_PUBLIC_TYPESENSE_PORT,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"setup": "is-in-ci || simple-git-hooks",
 		"start": "next start",
 		"test": "exit 0",
-		"test:e2e": "playwright test --config ./config/playwright.config.ts",
+		"test:e2e": "playwright test --config ./e2e/playwright.config.ts --pass-with-no-tests",
 		"test:e2e:codegen": "playwright codegen",
 		"test:e2e:install": "playwright install --with-deps",
 		"test:e2e:ui": "pnpm run test:e2e --ui",


### PR DESCRIPTION
run format, lint, and e2e tests on pull request branches. cms branches (starting with "content/") are ignored.

currently, vercel preview deployment happens in parallel, and is not dependent on a successful validation pipeline.