### PR TITLE
feat: add share on bluesky and share on linkedin links

### DIFF
--- a/components/social-media-share-links.tsx
+++ b/components/social-media-share-links.tsx
@@ -51,8 +51,9 @@ export function SocialMediaShareLinks(props: Readonly<SocialMediaShareLinksProps
 		linkedin: {
 			href: createUrl({
 				baseUrl: "https://www.linkedin.com",
-				pathname: "/sharing/share-offsite/",
+				pathname: "/shareArticle/",
 				searchParams: createUrlSearchParams({
+					mini: "true",
 					url,
 				}),
 			}),

--- a/components/social-media-share-links.tsx
+++ b/components/social-media-share-links.tsx
@@ -3,7 +3,12 @@ import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 
 import { Link } from "@/components/link";
-import { FacebookIcon, TwitterIcon } from "@/components/social-media-icons";
+import {
+	BlueskyIcon,
+	FacebookIcon,
+	LinkedInIcon,
+	TwitterIcon,
+} from "@/components/social-media-icons";
 import { useMetadata } from "@/lib/i18n/metadata";
 
 interface SocialMediaShareLinksProps {
@@ -19,47 +24,76 @@ export function SocialMediaShareLinks(props: Readonly<SocialMediaShareLinksProps
 
 	const twitter = meta.social.twitter;
 
+	const links = {
+		bluesky: {
+			href: createUrl({
+				baseUrl: "https://bsky.app",
+				pathname: "/intent/compose",
+				searchParams: createUrlSearchParams({
+					text: [title, url].join(" "),
+				}),
+			}),
+			icon: <BlueskyIcon />,
+			label: t("share-link", { platform: "Bluesky" }),
+		},
+		facebook: {
+			href: createUrl({
+				baseUrl: "https://www.facebook.com",
+				pathname: "/sharer/sharer.php",
+				searchParams: createUrlSearchParams({
+					u: url,
+					title: title,
+				}),
+			}),
+			icon: <FacebookIcon />,
+			label: t("share-link", { platform: "Facebook" }),
+		},
+		linkedin: {
+			href: createUrl({
+				baseUrl: "https://www.linkedin.com",
+				pathname: "/sharing/share-offsite/",
+				searchParams: createUrlSearchParams({
+					url,
+				}),
+			}),
+			icon: <LinkedInIcon />,
+			label: t("share-link", { platform: "LinkedIn" }),
+		},
+		twitter: {
+			href: createUrl({
+				baseUrl: "https://www.twitter.com",
+				pathname: "/intent/tweet",
+				searchParams: createUrlSearchParams({
+					text: title,
+					url,
+					via: twitter,
+					related: String(
+						createUrl({
+							baseUrl: "https://www.twitter.com",
+							pathname: twitter,
+						}),
+					),
+				}),
+			}),
+			icon: <TwitterIcon />,
+			label: t("share-link", { platform: "Twitter" }),
+		},
+	};
+
 	return (
 		<div className="my-8 flex items-center justify-center gap-x-4 text-neutral-500">
-			<Link
-				className="block rounded-full transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-				href={String(
-					createUrl({
-						baseUrl: "https://www.twitter.com",
-						pathname: "/intent/tweet",
-						searchParams: createUrlSearchParams({
-							text: title,
-							url,
-							via: twitter,
-							related: String(
-								createUrl({
-									baseUrl: "https://www.twitter.com",
-									pathname: twitter,
-								}),
-							),
-						}),
-					}),
-				)}
-			>
-				<TwitterIcon />
-				<span className="sr-only">{t("share-link", { platform: "Twitter" })}</span>
-			</Link>
-			<Link
-				className="block rounded-full transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-				href={String(
-					createUrl({
-						baseUrl: "https://www.facebook.com",
-						pathname: "/sharer/sharer.php",
-						searchParams: createUrlSearchParams({
-							u: url,
-							title: title,
-						}),
-					}),
-				)}
-			>
-				<FacebookIcon />
-				<span className="sr-only">{t("share-link", { platform: "Facebook" })}</span>
-			</Link>
+			{Object.entries(links).map(([id, link]) => {
+				return (
+					<Link
+						key={id}
+						className="block rounded-full transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
+						href={String(link.href)}
+					>
+						{link.icon}
+						<span className="sr-only">{link.label}</span>
+					</Link>
+				);
+			})}
 		</div>
 	);
 }


### PR DESCRIPTION
this adds "share on bluesky" and "share on linkedin" links, in addition to twitter and facebook.

somebody with accounts needs to check if this works. especially if the linkedin link works, because their docs are unclear.

closes #1564