### PR TITLE
fix: update label for part-of-curriculum links

### DIFF
--- a/components/curricula-list.tsx
+++ b/components/curricula-list.tsx
@@ -27,10 +27,10 @@ export function CurriculaList(props: Readonly<CurriculaListProps>): ReactNode {
 					return (
 						<li key={id}>
 							<Link
-								className="relative flex items-center gap-x-1.5 rounded text-sm transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
+								className="relative flex items-baseline gap-x-1.5 rounded text-sm transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
 								href={href}
 							>
-								<ContentTypeIcon className="size-4 shrink-0" kind="curriculum" />
+								<ContentTypeIcon className="size-4 shrink-0 translate-y-0.5" kind="curriculum" />
 								<span>{title}</span>
 							</Link>
 						</li>

--- a/messages/en.json
+++ b/messages/en.json
@@ -137,7 +137,7 @@
 		"attachments": "Attachments",
 		"authors": "Authors",
 		"close": "Close",
-		"contained-in-curricula": "Contained in {count, plural, =1 {this curriculum} other {these curricula}}",
+		"contained-in-curricula": "Part of {count, plural, =1 {this curriculum} other {these curricula}}",
 		"contributors": "Contributors",
 		"date": "Date",
 		"editors": "Editors",
@@ -164,7 +164,7 @@
 	"ExternalResourcePage": {
 		"authors": "Authors",
 		"close": "Close",
-		"contained-in-curricula": "Contained in {count, plural, =1 {this curriculum} other {these curricula}}",
+		"contained-in-curricula": "Part of {count, plural, =1 {this curriculum} other {these curricula}}",
 		"contributors": "Contributors",
 		"editors": "Editors",
 		"is-translation-of": "Is translation of",
@@ -182,7 +182,7 @@
 	"HostedResourcePage": {
 		"authors": "Authors",
 		"close": "Close",
-		"contained-in-curricula": "Contained in {count, plural, =1 {this curriculum} other {these curricula}}",
+		"contained-in-curricula": "Part of {count, plural, =1 {this curriculum} other {these curricula}}",
 		"contributors": "Contributors",
 		"editors": "Editors",
 		"is-translation-of": "Is translation of",
@@ -216,7 +216,7 @@
 	"PathfinderResourcePage": {
 		"authors": "Authors",
 		"close": "Close",
-		"contained-in-curricula": "Contained in {count, plural, =1 {this curriculum} other {these curricula}}",
+		"contained-in-curricula": "Part of {count, plural, =1 {this curriculum} other {these curricula}}",
 		"contributors": "Contributors",
 		"editors": "Editors",
 		"is-translation-of": "Is translation of",

--- a/messages/en.json
+++ b/messages/en.json
@@ -137,7 +137,7 @@
 		"attachments": "Attachments",
 		"authors": "Authors",
 		"close": "Close",
-		"contained-in-curricula": "Part of {count, plural, =1 {this curriculum} other {these curricula}}",
+		"contained-in-curricula": "Part of {count, plural, =1 {curriculum} other {curricula}}",
 		"contributors": "Contributors",
 		"date": "Date",
 		"editors": "Editors",
@@ -164,7 +164,7 @@
 	"ExternalResourcePage": {
 		"authors": "Authors",
 		"close": "Close",
-		"contained-in-curricula": "Part of {count, plural, =1 {this curriculum} other {these curricula}}",
+		"contained-in-curricula": "Part of {count, plural, =1 {curriculum} other {curricula}}",
 		"contributors": "Contributors",
 		"editors": "Editors",
 		"is-translation-of": "Is translation of",
@@ -182,7 +182,7 @@
 	"HostedResourcePage": {
 		"authors": "Authors",
 		"close": "Close",
-		"contained-in-curricula": "Part of {count, plural, =1 {this curriculum} other {these curricula}}",
+		"contained-in-curricula": "Part of {count, plural, =1 {curriculum} other {curricula}}",
 		"contributors": "Contributors",
 		"editors": "Editors",
 		"is-translation-of": "Is translation of",
@@ -216,7 +216,7 @@
 	"PathfinderResourcePage": {
 		"authors": "Authors",
 		"close": "Close",
-		"contained-in-curricula": "Part of {count, plural, =1 {this curriculum} other {these curricula}}",
+		"contained-in-curricula": "Part of {count, plural, =1 {curriculum} other {curricula}}",
 		"contributors": "Contributors",
 		"editors": "Editors",
 		"is-translation-of": "Is translation of",


### PR DESCRIPTION
resources can be part of one or more curricula, and we link to these curricula from the sidepanel.

currently the label says "Contained in this curriculum:" or "Contained in these curricula" - but according to rolling minutes we wanted to change this to "Part of curriculum:" / "Part of curricula". 