### PR TITLE
feat: add citation to curriculum metadata sidepanel

### DIFF
--- a/app/(app)/(default)/curricula/[id]/page.tsx
+++ b/app/(app)/(default)/curricula/[id]/page.tsx
@@ -4,15 +4,19 @@ import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 
+import { Citation } from "@/components/citation";
 import { Curriculum } from "@/components/curriculum";
 import { CurriculumResourcesList } from "@/components/curriculum-resources-list";
 import { PeopleList } from "@/components/people-list";
+import { ReUseConditions } from "@/components/re-use-conditions";
 import { RelatedCurriculaList } from "@/components/related-curricula-list";
 import { TagsList } from "@/components/tags-list";
 import { TranslationOf } from "@/components/translation-of";
 import { TranslationsList } from "@/components/translations-list";
+import { env } from "@/config/env.config";
 import { client } from "@/lib/content/client";
 import { createClient } from "@/lib/content/create-client";
+import { createFullUrl } from "@/lib/navigation/create-full-url";
 import { pickRandom } from "@/lib/utils/pick-random";
 
 interface CurriculumPageProps extends PageProps<"/curricula/[id]"> {}
@@ -70,13 +74,16 @@ export default async function CurriculumPage(
 	}
 
 	const {
+		doi,
 		editors,
 		"featured-image": featuredImage,
+		"publication-date": publicationDate,
 		resources,
 		tags,
 		title,
 		translations: _translations,
 		"is-translation-of": _isTranslationOf,
+		version,
 	} = curriculum.metadata;
 
 	const Content = curriculum.content;
@@ -143,6 +150,30 @@ export default async function CurriculumPage(
 							}),
 						)}
 					/>
+					<Citation
+						authors={await Promise.all(
+							editors.map(async (id) => {
+								const person = await client.collections.people.get(id);
+								assert(person, `Missing person "${id}".`);
+								const { image, name } = person.metadata;
+								return { id, image, name };
+							}),
+						)}
+						contentType="curriculum"
+						publicationDate={new Date(publicationDate)}
+						title={title}
+						url={
+							doi ||
+							String(
+								createFullUrl({
+									baseUrl: env.NEXT_PUBLIC_APP_PRODUCTION_BASE_URL,
+									pathname: curriculum.href,
+								}),
+							)
+						}
+						version={version}
+					/>
+					<ReUseConditions />
 				</aside>
 
 				<div className="min-w-0">
@@ -227,6 +258,33 @@ export default async function CurriculumPage(
 							}),
 						)}
 					/>
+
+					<div className="mx-auto mt-12 flex w-full max-w-(--size-content) flex-col gap-y-12 border-t border-neutral-200 pt-12 text-sm text-neutral-500 2xl:hidden">
+						<Citation
+							authors={await Promise.all(
+								editors.map(async (id) => {
+									const person = await client.collections.people.get(id);
+									assert(person, `Missing person "${id}".`);
+									const { image, name } = person.metadata;
+									return { id, image, name };
+								}),
+							)}
+							contentType="curriculum"
+							publicationDate={new Date(publicationDate)}
+							title={title}
+							url={
+								doi ||
+								String(
+									createFullUrl({
+										baseUrl: env.NEXT_PUBLIC_APP_PRODUCTION_BASE_URL,
+										pathname: curriculum.href,
+									}),
+								)
+							}
+							version={version}
+						/>
+						<ReUseConditions />
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
this adds a "Cite as" and "Re-use conditions" block to the curriculum details pages.

closes #1595 
