### PR TITLE
feat: add optional field for dariah member country affiliations

### DIFF
--- a/content/en/dariah-national-consortia/at.json
+++ b/content/en/dariah-national-consortia/at.json
@@ -1,0 +1,5 @@
+{
+  "code": "at",
+  "name": "CLARIAH-AT",
+  "sshoc-marketplace-id": "9403"
+}

--- a/content/en/dariah-national-consortia/be.json
+++ b/content/en/dariah-national-consortia/be.json
@@ -1,0 +1,5 @@
+{
+  "code": "be",
+  "name": "DARIAH-BE",
+  "sshoc-marketplace-id": "3235"
+}

--- a/content/en/dariah-national-consortia/bg.json
+++ b/content/en/dariah-national-consortia/bg.json
@@ -1,0 +1,5 @@
+{
+  "code": "bg",
+  "name": "CLaDA-BG",
+  "sshoc-marketplace-id": "3754"
+}

--- a/content/en/dariah-national-consortia/ch.json
+++ b/content/en/dariah-national-consortia/ch.json
@@ -1,0 +1,5 @@
+{
+  "code": "ch",
+  "name": "DARIAH-CH",
+  "sshoc-marketplace-id": "10002"
+}

--- a/content/en/dariah-national-consortia/cz.json
+++ b/content/en/dariah-national-consortia/cz.json
@@ -1,0 +1,5 @@
+{
+  "code": "cz",
+  "name": "LINDAT/CLARIAH-CZ",
+  "sshoc-marketplace-id": "3804"
+}

--- a/content/en/dariah-national-consortia/de.json
+++ b/content/en/dariah-national-consortia/de.json
@@ -1,0 +1,5 @@
+{
+  "code": "de",
+  "name": "DARIAH-DE",
+  "sshoc-marketplace-id": "2868"
+}

--- a/content/en/dariah-national-consortia/dk.json
+++ b/content/en/dariah-national-consortia/dk.json
@@ -1,0 +1,5 @@
+{
+  "code": "dk",
+  "name": "DARIAH-DK",
+  "sshoc-marketplace-id": "9560"
+}

--- a/content/en/dariah-national-consortia/es.json
+++ b/content/en/dariah-national-consortia/es.json
@@ -1,0 +1,5 @@
+{
+  "code": "es",
+  "name": "CLARIAH-ES",
+  "sshoc-marketplace-id": "11803"
+}

--- a/content/en/dariah-national-consortia/fr.json
+++ b/content/en/dariah-national-consortia/fr.json
@@ -1,0 +1,5 @@
+{
+  "code": "fr",
+  "name": "DARIAH-FR",
+  "sshoc-marketplace-id": "10860"
+}

--- a/content/en/dariah-national-consortia/gr.json
+++ b/content/en/dariah-national-consortia/gr.json
@@ -1,0 +1,5 @@
+{
+  "code": "gr",
+  "name": "DARIAH-GR / DYAS",
+  "sshoc-marketplace-id": "3502"
+}

--- a/content/en/dariah-national-consortia/hr.json
+++ b/content/en/dariah-national-consortia/hr.json
@@ -1,0 +1,5 @@
+{
+  "code": "hr",
+  "name": "DARIAH-HR",
+  "sshoc-marketplace-id": "3403"
+}

--- a/content/en/dariah-national-consortia/ie.json
+++ b/content/en/dariah-national-consortia/ie.json
@@ -1,0 +1,5 @@
+{
+  "code": "ie",
+  "name": "DARIAH-IE",
+  "sshoc-marketplace-id": "3755"
+}

--- a/content/en/dariah-national-consortia/it.json
+++ b/content/en/dariah-national-consortia/it.json
@@ -1,0 +1,5 @@
+{
+  "code": "it",
+  "name": "DARIAH-IT",
+  "sshoc-marketplace-id": "10226"
+}

--- a/content/en/dariah-national-consortia/lu.json
+++ b/content/en/dariah-national-consortia/lu.json
@@ -1,0 +1,5 @@
+{
+  "code": "lu",
+  "name": "DARIAH-LU",
+  "sshoc-marketplace-id": "9561"
+}

--- a/content/en/dariah-national-consortia/nl.json
+++ b/content/en/dariah-national-consortia/nl.json
@@ -1,0 +1,5 @@
+{
+  "code": "nl",
+  "name": "CLARIAH-NL",
+  "sshoc-marketplace-id": "9562"
+}

--- a/content/en/dariah-national-consortia/pl.json
+++ b/content/en/dariah-national-consortia/pl.json
@@ -1,0 +1,5 @@
+{
+  "code": "pl",
+  "name": "DARIAH-PL",
+  "sshoc-marketplace-id": "3752"
+}

--- a/content/en/dariah-national-consortia/pt.json
+++ b/content/en/dariah-national-consortia/pt.json
@@ -1,0 +1,5 @@
+{
+  "code": "pt",
+  "name": "DARIAH-PT / ROSSIO",
+  "sshoc-marketplace-id": "3553"
+}

--- a/content/en/dariah-national-consortia/se.json
+++ b/content/en/dariah-national-consortia/se.json
@@ -1,0 +1,5 @@
+{
+  "code": "se",
+  "name": "DARIAH-SE/Huminfra",
+  "sshoc-marketplace-id": "10722"
+}

--- a/content/en/dariah-national-consortia/si.json
+++ b/content/en/dariah-national-consortia/si.json
@@ -1,0 +1,5 @@
+{
+  "code": "si",
+  "name": "DARIAH-SI",
+  "sshoc-marketplace-id": "9133"
+}

--- a/lib/content/keystatic/collections/curricula.ts
+++ b/lib/content/keystatic/collections/curricula.ts
@@ -172,10 +172,10 @@ export const createCurricula = createCollection("/curricula/", (paths, locale) =
 				collection: withI18nPrefix("curricula", locale),
 			}),
 			"dariah-national-consortia": fields.multiRelationship({
-				label: "DARIAH National Consortia",
+				label: "DARIAH national consortia",
 				validation: { length: { min: 0 } },
 				collection: withI18nPrefix("dariah-national-consortia", locale),
-				description: "DARIAH member country affiliation",
+				description: "DARIAH member countries contributing to resource (where applicable)",
 			}),
 			doi: readonly({
 				label: "PID (readonly)",

--- a/lib/content/keystatic/collections/curricula.ts
+++ b/lib/content/keystatic/collections/curricula.ts
@@ -22,7 +22,7 @@ import { createTabs } from "@/lib/content/keystatic/components/tabs";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createVideoCard } from "@/lib/content/keystatic/components/video-card";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
-import { contentLanguages, contentLicenses } from "@/lib/content/options";
+import { contentLanguages, contentLicenses, dariahNationalConsortia } from "@/lib/content/options";
 
 export const createCurricula = createCollection("/curricula/", (paths, locale) => {
 	return collection({
@@ -170,6 +170,11 @@ export const createCurricula = createCollection("/curricula/", (paths, locale) =
 				label: "Is translation of",
 				validation: { isRequired: false },
 				collection: withI18nPrefix("curricula", locale),
+			}),
+			"dariah-national-consortia": fields.multiselect({
+				label: "DARIAH National Consortia",
+				options: dariahNationalConsortia,
+				description: "DARIAH member country affiliation",
 			}),
 			doi: readonly({
 				label: "PID (readonly)",

--- a/lib/content/keystatic/collections/curricula.ts
+++ b/lib/content/keystatic/collections/curricula.ts
@@ -22,7 +22,7 @@ import { createTabs } from "@/lib/content/keystatic/components/tabs";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createVideoCard } from "@/lib/content/keystatic/components/video-card";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
-import { contentLanguages, contentLicenses, dariahNationalConsortia } from "@/lib/content/options";
+import { contentLanguages, contentLicenses } from "@/lib/content/options";
 
 export const createCurricula = createCollection("/curricula/", (paths, locale) => {
 	return collection({
@@ -171,9 +171,10 @@ export const createCurricula = createCollection("/curricula/", (paths, locale) =
 				validation: { isRequired: false },
 				collection: withI18nPrefix("curricula", locale),
 			}),
-			"dariah-national-consortia": fields.multiselect({
+			"dariah-national-consortia": fields.multiRelationship({
 				label: "DARIAH National Consortia",
-				options: dariahNationalConsortia,
+				validation: { length: { min: 0 } },
+				collection: withI18nPrefix("dariah-national-consortia", locale),
 				description: "DARIAH member country affiliation",
 			}),
 			doi: readonly({

--- a/lib/content/keystatic/collections/dariah-national-consortia.ts
+++ b/lib/content/keystatic/collections/dariah-national-consortia.ts
@@ -1,0 +1,32 @@
+import { createCollection } from "@acdh-oeaw/keystatic-lib";
+import { collection, fields } from "@keystatic/core";
+
+export const createDariahNationalConsortia = createCollection(
+	"/dariah-national-consortia/",
+	(paths, locale) => {
+		return collection({
+			label: "DARIAH national consortia",
+			path: `./content/${locale}/dariah-national-consortia/*`,
+			format: { data: "json" },
+			slugField: "code",
+			columns: ["name"],
+			entryLayout: "form",
+			schema: {
+				code: fields.slug({
+					name: {
+						label: "Country code",
+						validation: { isRequired: true },
+					},
+				}),
+				name: fields.text({
+					label: "Name",
+					validation: { isRequired: true },
+				}),
+				"sshoc-marketplace-id": fields.text({
+					label: "SSHOC marketplace identifier",
+					validation: { isRequired: true },
+				}),
+			},
+		});
+	},
+);

--- a/lib/content/keystatic/collections/resources/events.ts
+++ b/lib/content/keystatic/collections/resources/events.ts
@@ -21,7 +21,12 @@ import { createTabs } from "@/lib/content/keystatic/components/tabs";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
 import * as validation from "@/lib/content/keystatic/validation";
-import { contentLanguages, contentLicenses, socialMediaKinds } from "@/lib/content/options";
+import {
+	contentLanguages,
+	contentLicenses,
+	dariahNationalConsortia,
+	socialMediaKinds,
+} from "@/lib/content/options";
 
 export const createResourcesEvents = createCollection("/resources/events/", (paths, locale) => {
 	return collection({
@@ -485,6 +490,11 @@ export const createResourcesEvents = createCollection("/resources/events/", (pat
 				label: "Is translation of",
 				validation: { isRequired: false },
 				collection: withI18nPrefix("resources-events", locale),
+			}),
+			"dariah-national-consortia": fields.multiselect({
+				label: "DARIAH National Consortia",
+				options: dariahNationalConsortia,
+				description: "DARIAH member country affiliation",
 			}),
 			doi: readonly({
 				label: "PID (readonly)",

--- a/lib/content/keystatic/collections/resources/events.ts
+++ b/lib/content/keystatic/collections/resources/events.ts
@@ -487,10 +487,10 @@ export const createResourcesEvents = createCollection("/resources/events/", (pat
 				collection: withI18nPrefix("resources-events", locale),
 			}),
 			"dariah-national-consortia": fields.multiRelationship({
-				label: "DARIAH National Consortia",
+				label: "DARIAH national consortia",
 				validation: { length: { min: 0 } },
 				collection: withI18nPrefix("dariah-national-consortia", locale),
-				description: "DARIAH member country affiliation",
+				description: "DARIAH member countries contributing to resource (where applicable)",
 			}),
 			doi: readonly({
 				label: "PID (readonly)",

--- a/lib/content/keystatic/collections/resources/events.ts
+++ b/lib/content/keystatic/collections/resources/events.ts
@@ -21,12 +21,7 @@ import { createTabs } from "@/lib/content/keystatic/components/tabs";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
 import * as validation from "@/lib/content/keystatic/validation";
-import {
-	contentLanguages,
-	contentLicenses,
-	dariahNationalConsortia,
-	socialMediaKinds,
-} from "@/lib/content/options";
+import { contentLanguages, contentLicenses, socialMediaKinds } from "@/lib/content/options";
 
 export const createResourcesEvents = createCollection("/resources/events/", (paths, locale) => {
 	return collection({
@@ -491,9 +486,10 @@ export const createResourcesEvents = createCollection("/resources/events/", (pat
 				validation: { isRequired: false },
 				collection: withI18nPrefix("resources-events", locale),
 			}),
-			"dariah-national-consortia": fields.multiselect({
+			"dariah-national-consortia": fields.multiRelationship({
 				label: "DARIAH National Consortia",
-				options: dariahNationalConsortia,
+				validation: { length: { min: 0 } },
+				collection: withI18nPrefix("dariah-national-consortia", locale),
 				description: "DARIAH member country affiliation",
 			}),
 			doi: readonly({

--- a/lib/content/keystatic/collections/resources/external.ts
+++ b/lib/content/keystatic/collections/resources/external.ts
@@ -18,12 +18,7 @@ import { createQuiz } from "@/lib/content/keystatic/components/quiz";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createVideoCard } from "@/lib/content/keystatic/components/video-card";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
-import {
-	contentLanguages,
-	contentLicenses,
-	contentTypes,
-	dariahNationalConsortia,
-} from "@/lib/content/options";
+import { contentLanguages, contentLicenses, contentTypes } from "@/lib/content/options";
 
 export const createResourcesExternal = createCollection("/resources/external/", (paths, locale) => {
 	return collection({
@@ -167,9 +162,10 @@ export const createResourcesExternal = createCollection("/resources/external/", 
 				validation: { isRequired: false },
 				collection: withI18nPrefix("resources-external", locale),
 			}),
-			"dariah-national-consortia": fields.multiselect({
+			"dariah-national-consortia": fields.multiRelationship({
 				label: "DARIAH National Consortia",
-				options: dariahNationalConsortia,
+				validation: { length: { min: 0 } },
+				collection: withI18nPrefix("dariah-national-consortia", locale),
 				description: "DARIAH member country affiliation",
 			}),
 			doi: readonly({

--- a/lib/content/keystatic/collections/resources/external.ts
+++ b/lib/content/keystatic/collections/resources/external.ts
@@ -18,7 +18,12 @@ import { createQuiz } from "@/lib/content/keystatic/components/quiz";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createVideoCard } from "@/lib/content/keystatic/components/video-card";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
-import { contentLanguages, contentLicenses, contentTypes } from "@/lib/content/options";
+import {
+	contentLanguages,
+	contentLicenses,
+	contentTypes,
+	dariahNationalConsortia,
+} from "@/lib/content/options";
 
 export const createResourcesExternal = createCollection("/resources/external/", (paths, locale) => {
 	return collection({
@@ -161,6 +166,11 @@ export const createResourcesExternal = createCollection("/resources/external/", 
 				label: "Is translation of",
 				validation: { isRequired: false },
 				collection: withI18nPrefix("resources-external", locale),
+			}),
+			"dariah-national-consortia": fields.multiselect({
+				label: "DARIAH National Consortia",
+				options: dariahNationalConsortia,
+				description: "DARIAH member country affiliation",
 			}),
 			doi: readonly({
 				label: "PID (readonly)",

--- a/lib/content/keystatic/collections/resources/external.ts
+++ b/lib/content/keystatic/collections/resources/external.ts
@@ -163,10 +163,10 @@ export const createResourcesExternal = createCollection("/resources/external/", 
 				collection: withI18nPrefix("resources-external", locale),
 			}),
 			"dariah-national-consortia": fields.multiRelationship({
-				label: "DARIAH National Consortia",
+				label: "DARIAH national consortia",
 				validation: { length: { min: 0 } },
 				collection: withI18nPrefix("dariah-national-consortia", locale),
-				description: "DARIAH member country affiliation",
+				description: "DARIAH member countries contributing to resource (where applicable)",
 			}),
 			doi: readonly({
 				label: "PID (readonly)",

--- a/lib/content/keystatic/collections/resources/hosted.ts
+++ b/lib/content/keystatic/collections/resources/hosted.ts
@@ -23,12 +23,7 @@ import { createTabs } from "@/lib/content/keystatic/components/tabs";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createVideoCard } from "@/lib/content/keystatic/components/video-card";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
-import {
-	contentLanguages,
-	contentLicenses,
-	contentTypes,
-	dariahNationalConsortia,
-} from "@/lib/content/options";
+import { contentLanguages, contentLicenses, contentTypes } from "@/lib/content/options";
 
 export const createResourcesHosted = createCollection("/resources/hosted/", (paths, locale) => {
 	return collection({
@@ -158,9 +153,10 @@ export const createResourcesHosted = createCollection("/resources/hosted/", (pat
 				validation: { isRequired: false },
 				collection: withI18nPrefix("resources-hosted", locale),
 			}),
-			"dariah-national-consortia": fields.multiselect({
+			"dariah-national-consortia": fields.multiRelationship({
 				label: "DARIAH National Consortia",
-				options: dariahNationalConsortia,
+				validation: { length: { min: 0 } },
+				collection: withI18nPrefix("dariah-national-consortia", locale),
 				description: "DARIAH member country affiliation",
 			}),
 			doi: readonly({

--- a/lib/content/keystatic/collections/resources/hosted.ts
+++ b/lib/content/keystatic/collections/resources/hosted.ts
@@ -23,7 +23,12 @@ import { createTabs } from "@/lib/content/keystatic/components/tabs";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createVideoCard } from "@/lib/content/keystatic/components/video-card";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
-import { contentLanguages, contentLicenses, contentTypes } from "@/lib/content/options";
+import {
+	contentLanguages,
+	contentLicenses,
+	contentTypes,
+	dariahNationalConsortia,
+} from "@/lib/content/options";
 
 export const createResourcesHosted = createCollection("/resources/hosted/", (paths, locale) => {
 	return collection({
@@ -152,6 +157,11 @@ export const createResourcesHosted = createCollection("/resources/hosted/", (pat
 				label: "Is translation of",
 				validation: { isRequired: false },
 				collection: withI18nPrefix("resources-hosted", locale),
+			}),
+			"dariah-national-consortia": fields.multiselect({
+				label: "DARIAH National Consortia",
+				options: dariahNationalConsortia,
+				description: "DARIAH member country affiliation",
 			}),
 			doi: readonly({
 				label: "PID (readonly)",

--- a/lib/content/keystatic/collections/resources/hosted.ts
+++ b/lib/content/keystatic/collections/resources/hosted.ts
@@ -154,10 +154,10 @@ export const createResourcesHosted = createCollection("/resources/hosted/", (pat
 				collection: withI18nPrefix("resources-hosted", locale),
 			}),
 			"dariah-national-consortia": fields.multiRelationship({
-				label: "DARIAH National Consortia",
+				label: "DARIAH national consortia",
 				validation: { length: { min: 0 } },
 				collection: withI18nPrefix("dariah-national-consortia", locale),
-				description: "DARIAH member country affiliation",
+				description: "DARIAH member countries contributing to resource (where applicable)",
 			}),
 			doi: readonly({
 				label: "PID (readonly)",

--- a/lib/content/keystatic/collections/resources/pathfinders.ts
+++ b/lib/content/keystatic/collections/resources/pathfinders.ts
@@ -20,7 +20,7 @@ import { createLinkButton } from "@/lib/content/keystatic/components/link-button
 import { createTabs } from "@/lib/content/keystatic/components/tabs";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
-import { contentLanguages, contentLicenses, dariahNationalConsortia } from "@/lib/content/options";
+import { contentLanguages, contentLicenses } from "@/lib/content/options";
 
 export const createResourcesPathfinders = createCollection(
 	"/resources/pathfinders/",
@@ -144,9 +144,10 @@ export const createResourcesPathfinders = createCollection(
 					validation: { isRequired: false },
 					collection: withI18nPrefix("resources-pathfinders", locale),
 				}),
-				"dariah-national-consortia": fields.multiselect({
+				"dariah-national-consortia": fields.multiRelationship({
 					label: "DARIAH National Consortia",
-					options: dariahNationalConsortia,
+					validation: { length: { min: 0 } },
+					collection: withI18nPrefix("dariah-national-consortia", locale),
 					description: "DARIAH member country affiliation",
 				}),
 				doi: readonly({

--- a/lib/content/keystatic/collections/resources/pathfinders.ts
+++ b/lib/content/keystatic/collections/resources/pathfinders.ts
@@ -20,7 +20,7 @@ import { createLinkButton } from "@/lib/content/keystatic/components/link-button
 import { createTabs } from "@/lib/content/keystatic/components/tabs";
 import { createVideo } from "@/lib/content/keystatic/components/video";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
-import { contentLanguages, contentLicenses } from "@/lib/content/options";
+import { contentLanguages, contentLicenses, dariahNationalConsortia } from "@/lib/content/options";
 
 export const createResourcesPathfinders = createCollection(
 	"/resources/pathfinders/",
@@ -143,6 +143,11 @@ export const createResourcesPathfinders = createCollection(
 					label: "Is translation of",
 					validation: { isRequired: false },
 					collection: withI18nPrefix("resources-pathfinders", locale),
+				}),
+				"dariah-national-consortia": fields.multiselect({
+					label: "DARIAH National Consortia",
+					options: dariahNationalConsortia,
+					description: "DARIAH member country affiliation",
 				}),
 				doi: readonly({
 					label: "PID (readonly)",

--- a/lib/content/keystatic/collections/resources/pathfinders.ts
+++ b/lib/content/keystatic/collections/resources/pathfinders.ts
@@ -145,10 +145,10 @@ export const createResourcesPathfinders = createCollection(
 					collection: withI18nPrefix("resources-pathfinders", locale),
 				}),
 				"dariah-national-consortia": fields.multiRelationship({
-					label: "DARIAH National Consortia",
+					label: "DARIAH national consortia",
 					validation: { length: { min: 0 } },
 					collection: withI18nPrefix("dariah-national-consortia", locale),
-					description: "DARIAH member country affiliation",
+					description: "DARIAH member countries contributing to resource (where applicable)",
 				}),
 				doi: readonly({
 					label: "PID (readonly)",

--- a/lib/content/keystatic/config.ts
+++ b/lib/content/keystatic/config.ts
@@ -3,6 +3,7 @@ import { config as createConfig } from "@keystatic/core";
 
 import { env } from "@/config/env.config";
 import { createCurricula } from "@/lib/content/keystatic/collections/curricula";
+import { createDariahNationalConsortia } from "@/lib/content/keystatic/collections/dariah-national-consortia";
 import { createDocumentation } from "@/lib/content/keystatic/collections/documentation";
 import { createPeople } from "@/lib/content/keystatic/collections/people";
 import { createResourcesEvents } from "@/lib/content/keystatic/collections/resources/events";
@@ -22,6 +23,7 @@ const locale = getIntlLanguage(defaultLocale);
 export const config = createConfig({
 	collections: {
 		[withI18nPrefix("curricula", locale)]: createCurricula(locale),
+		[withI18nPrefix("dariah-national-consortia", locale)]: createDariahNationalConsortia(locale),
 		[withI18nPrefix("documentation", locale)]: createDocumentation(locale),
 		[withI18nPrefix("resources-events", locale)]: createResourcesEvents(locale),
 		[withI18nPrefix("people", locale)]: createPeople(locale),
@@ -68,6 +70,7 @@ export const config = createConfig({
 				withI18nPrefix("people", locale),
 				withI18nPrefix("sources", locale),
 				withI18nPrefix("tags", locale),
+				// withI18nPrefix("dariah-national-consortia", locale),
 			],
 			Pages: [withI18nPrefix("index-page", locale), withI18nPrefix("documentation", locale)],
 			Settings: [withI18nPrefix("navigation", locale), withI18nPrefix("metadata", locale)],

--- a/lib/content/options.ts
+++ b/lib/content/options.ts
@@ -32,30 +32,6 @@ export const contentTypes = [
 
 export type ContentType = (typeof contentTypes)[number]["value"];
 
-export const dariahNationalConsortia = [
-	{ label: "CLARIAH-AT", value: "9403" },
-	{ label: "DARIAH-BE", value: "3235" },
-	{ label: "CLaDA-BG", value: "3754" },
-	{ label: "DARIAH-CH", value: "10002" },
-	{ label: "LINDAT/CLARIAH-CZ", value: "3804" },
-	{ label: "DARIAH-DE", value: "2868" },
-	{ label: "DARIAH-DK", value: "9560" },
-	{ label: "CLARIAH-ES", value: "11803" },
-	{ label: "DARIAH-FR", value: "10860" },
-	{ label: "DARIAH-GR / DYAS", value: "3502" },
-	{ label: "DARIAH-HR", value: "3403" },
-	{ label: "DARIAH-IE", value: "3755" },
-	{ label: "DARIAH-IT", value: "10226" },
-	{ label: "DARIAH-LU", value: "9561" },
-	{ label: "CLARIAH-NL", value: "9562" },
-	{ label: "DARIAH-PL", value: "3752" },
-	{ label: "DARIAH-PT / ROSSIO", value: "3553" },
-	{ label: "DARIAH-SE/Huminfra", value: "10722" },
-	{ label: "DARIAH-SI", value: "9133" },
-] as const;
-
-export type DariahNationalConsortium = (typeof dariahNationalConsortia)[number]["value"];
-
 export const figureAlignments = [
 	{ label: "Center", value: "center" },
 	{ label: "Stretch", value: "stretch" },

--- a/lib/content/options.ts
+++ b/lib/content/options.ts
@@ -32,6 +32,30 @@ export const contentTypes = [
 
 export type ContentType = (typeof contentTypes)[number]["value"];
 
+export const dariahNationalConsortia = [
+	{ label: "CLARIAH-AT", value: "9403" },
+	{ label: "DARIAH-BE", value: "3235" },
+	{ label: "CLaDA-BG", value: "3754" },
+	{ label: "DARIAH-CH", value: "10002" },
+	{ label: "LINDAT/CLARIAH-CZ", value: "3804" },
+	{ label: "DARIAH-DE", value: "2868" },
+	{ label: "DARIAH-DK", value: "9560" },
+	{ label: "CLARIAH-ES", value: "11803" },
+	{ label: "DARIAH-FR", value: "10860" },
+	{ label: "DARIAH-GR / DYAS", value: "3502" },
+	{ label: "DARIAH-HR", value: "3403" },
+	{ label: "DARIAH-IE", value: "3755" },
+	{ label: "DARIAH-IT", value: "10226" },
+	{ label: "DARIAH-LU", value: "9561" },
+	{ label: "CLARIAH-NL", value: "9562" },
+	{ label: "DARIAH-PL", value: "3752" },
+	{ label: "DARIAH-PT / ROSSIO", value: "3553" },
+	{ label: "DARIAH-SE/Huminfra", value: "10722" },
+	{ label: "DARIAH-SI", value: "9133" },
+] as const;
+
+export type DariahNationalConsortium = (typeof dariahNationalConsortia)[number]["value"];
+
 export const figureAlignments = [
 	{ label: "Center", value: "center" },
 	{ label: "Stretch", value: "stretch" },


### PR DESCRIPTION
this adds an optional field to record dariah member country affiliations, which are stored as ssh open marketplace identifiers.

closes #1596

QUESTION: should this field be added to hosted resources only, or to all resources and curricula?

QUESTION: can someone provide a descriptive help text for this field?