### PR TITLE
fix: improve image comparison slider a11y

### DIFF
--- a/components/content/image-comparison-slider.tsx
+++ b/components/content/image-comparison-slider.tsx
@@ -35,9 +35,20 @@ export function ImageComparisonSlider(props: Readonly<ImageComparisonSliderProps
 		<figure className="flex flex-col">
 			<div
 				ref={init}
-				className="group not-prose relative grid min-h-12 cursor-pointer touch-none rounded border border-neutral-200"
+				className={cn(
+					"group not-prose relative grid min-h-12 touch-none rounded border border-neutral-200",
+					isDragging
+						? orientation === "vertical"
+							? "cursor-row-resize"
+							: "cursor-col-resize"
+						: "cursor-pointer",
+				)}
+				data-dragging={isDragging}
 				data-orientation={orientation}
 				onPointerDown={(event) => {
+					if (event.button !== 0) {
+						return;
+					}
 					setIsDragging(true);
 					const dimensions = event.currentTarget.getBoundingClientRect();
 					const position =
@@ -96,6 +107,7 @@ export function ImageComparisonSlider(props: Readonly<ImageComparisonSliderProps
 								: "inset(0 0 0 var(--position))",
 					}}
 				/>
+				{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
 				<div
 					className={cn(
 						"absolute grid place-items-center",
@@ -103,8 +115,42 @@ export function ImageComparisonSlider(props: Readonly<ImageComparisonSliderProps
 							? "w-full translate-y-[calc(var(--position)-50%)] cursor-row-resize"
 							: "h-full translate-x-[calc(var(--position)-50%)] cursor-col-resize",
 					)}
+					onKeyDown={(event) => {
+						if (orientation === "vertical") {
+							switch (event.key) {
+								case "ArrowUp": {
+									const newPosition = Math.max(position - 10, 0);
+									setPosition(newPosition);
+									break;
+								}
+
+								case "ArrowDown": {
+									const dimensions = event.currentTarget.getBoundingClientRect();
+									const newPosition = Math.min(position + 10, dimensions.height);
+									setPosition(newPosition);
+									break;
+								}
+							}
+						} else {
+							switch (event.key) {
+								case "ArrowLeft": {
+									const newPosition = Math.max(position - 10, 0);
+									setPosition(newPosition);
+									break;
+								}
+
+								case "ArrowRight": {
+									const dimensions = event.currentTarget.getBoundingClientRect();
+									const newPosition = Math.min(position + 10, dimensions.width);
+									setPosition(newPosition);
+									break;
+								}
+							}
+						}
+					}}
 					role="separator"
-					tabIndex={-1}
+					// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+					tabIndex={0}
 				>
 					<div
 						className={cn(

--- a/components/content/image-comparison-slider.tsx
+++ b/components/content/image-comparison-slider.tsx
@@ -109,6 +109,7 @@ export function ImageComparisonSlider(props: Readonly<ImageComparisonSliderProps
 				/>
 				{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
 				<div
+					aria-label="Use arrow keys to move separator"
 					className={cn(
 						"absolute grid place-items-center",
 						orientation === "vertical"
@@ -125,7 +126,7 @@ export function ImageComparisonSlider(props: Readonly<ImageComparisonSliderProps
 								}
 
 								case "ArrowDown": {
-									const dimensions = event.currentTarget.getBoundingClientRect();
+									const dimensions = event.currentTarget.parentElement!.getBoundingClientRect();
 									const newPosition = Math.min(position + 10, dimensions.height);
 									setPosition(newPosition);
 									break;
@@ -140,7 +141,7 @@ export function ImageComparisonSlider(props: Readonly<ImageComparisonSliderProps
 								}
 
 								case "ArrowRight": {
-									const dimensions = event.currentTarget.getBoundingClientRect();
+									const dimensions = event.currentTarget.parentElement!.getBoundingClientRect();
 									const newPosition = Math.min(position + 10, dimensions.width);
 									setPosition(newPosition);
 									break;

--- a/lib/content/keystatic/components/image-comparison-slider/preview.tsx
+++ b/lib/content/keystatic/components/image-comparison-slider/preview.tsx
@@ -42,7 +42,15 @@ export function ImageComparisonSliderPreview(
 		<figure className="flex flex-col">
 			<NotEditable
 				ref={init}
-				className="group not-prose relative grid min-h-12 cursor-pointer touch-none rounded border border-neutral-200"
+				className={cn(
+					"group not-prose relative grid min-h-12 touch-none rounded border border-neutral-200",
+					isDragging
+						? orientation === "vertical"
+							? "cursor-row-resize"
+							: "cursor-col-resize"
+						: "cursor-pointer",
+				)}
+				data-dragging={isDragging}
 				data-orientation={orientation}
 				onPointerDown={(event) => {
 					setIsDragging(true);
@@ -103,15 +111,51 @@ export function ImageComparisonSliderPreview(
 								: "inset(0 0 0 var(--position))",
 					}}
 				/>
+				{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
 				<div
+					aria-label="Use arrow keys to move separator"
 					className={cn(
 						"absolute grid place-items-center",
 						orientation === "vertical"
 							? "w-full translate-y-[calc(var(--position)-50%)] cursor-row-resize"
 							: "h-full translate-x-[calc(var(--position)-50%)] cursor-col-resize",
 					)}
+					onKeyDown={(event) => {
+						if (orientation === "vertical") {
+							switch (event.key) {
+								case "ArrowUp": {
+									const newPosition = Math.max(position - 10, 0);
+									setPosition(newPosition);
+									break;
+								}
+
+								case "ArrowDown": {
+									const dimensions = event.currentTarget.parentElement!.getBoundingClientRect();
+									const newPosition = Math.min(position + 10, dimensions.height);
+									setPosition(newPosition);
+									break;
+								}
+							}
+						} else {
+							switch (event.key) {
+								case "ArrowLeft": {
+									const newPosition = Math.max(position - 10, 0);
+									setPosition(newPosition);
+									break;
+								}
+
+								case "ArrowRight": {
+									const dimensions = event.currentTarget.parentElement!.getBoundingClientRect();
+									const newPosition = Math.min(position + 10, dimensions.width);
+									setPosition(newPosition);
+									break;
+								}
+							}
+						}
+					}}
 					role="separator"
-					tabIndex={-1}
+					// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+					tabIndex={0}
 				>
 					<div
 						className={cn(


### PR DESCRIPTION
this allows moving the separator in image comparison widgets with arrow keys