### PR TITLE
fix: prevent disclosure content from overflowing

### DIFF
--- a/components/content/disclosure.tsx
+++ b/components/content/disclosure.tsx
@@ -10,7 +10,7 @@ export function Disclosure(props: Readonly<DisclosureProps>): ReactNode {
 	const { children, title } = props;
 
 	return (
-		<details className="group my-4 grid border-y border-neutral-200 open:pb-4">
+		<details className="group my-4 flex flex-col border-y border-neutral-200 open:pb-4">
 			<summary className="my-3 inline-flex cursor-pointer list-none items-center justify-between gap-x-4 py-1 font-bold group-open:pb-0 hover:underline">
 				<span>{title}</span>
 				<ChevronDownIcon

--- a/lib/content/keystatic/components/disclosure/preview.tsx
+++ b/lib/content/keystatic/components/disclosure/preview.tsx
@@ -11,7 +11,7 @@ export function DisclosurePreview(props: Readonly<DisclosurePreviewProps>): Reac
 	const { children, title } = props;
 
 	return (
-		<details className="group my-4 grid border-y border-neutral-200 open:pb-4" open={true}>
+		<details className="group my-4 flex flex-col border-y border-neutral-200 open:pb-4" open={true}>
 			<summary className="my-3 inline-flex cursor-pointer list-none py-1 font-bold group-open:pb-0 hover:underline focus:outline-none">
 				<NotEditable className="inline-flex flex-1 items-center justify-between gap-x-4">
 					<span>{title || "(Disclosure title)"}</span>


### PR DESCRIPTION
use flex instead of grid (because grid items grow based on content)
closes #1606