### PR TITLE
Revert "fix: allow sources without resources (#1590)"

### DIFF
--- a/app/(app)/(default)/(index)/page.tsx
+++ b/app/(app)/(default)/(index)/page.tsx
@@ -274,12 +274,12 @@ async function TeamSection(props: Readonly<TeamSectionProps>): Promise<ReactNode
 			<SectionTitle>{title}</SectionTitle>
 			<SectionLead>{lead}</SectionLead>
 			<ul
-        className={cn(
+				className={cn(
 					"mx-auto grid grid-cols-2 gap-8 py-6",
 					team.length % 2 === 0 ? "md:grid-cols-4" : "md:grid-cols-3",
 				)}
-        role="list"
-       >
+				role="list"
+			>
 				{await Promise.all(
 					team.map(async (item, index) => {
 						const { person: id, role } = item;

--- a/app/(app)/(default)/sources/page.tsx
+++ b/app/(app)/(default)/sources/page.tsx
@@ -1,4 +1,4 @@
-import { groupByToMap } from "@acdh-oeaw/lib";
+import { assert, groupByToMap } from "@acdh-oeaw/lib";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
@@ -37,7 +37,8 @@ export default async function SourcesPage(): Promise<ReactNode> {
 		const href = `/sources/${source.id}`;
 
 		const resources = resourcesBySourceId.get(source.id);
-		const count = resources?.length ?? 0;
+		assert(resources, `Missing resources for source "${source.id}".`);
+		const count = resources.length;
 
 		return {
 			id: source.id,


### PR DESCRIPTION
This reverts commit 608aacc2914d0000808845378d9a4627c22910b8.

This removes the temporary workaround to allow sources without resources.