### PR TITLE
style: display footnote section heading

### DIFF
--- a/lib/content/mdx/remark-rehype-options.ts
+++ b/lib/content/mdx/remark-rehype-options.ts
@@ -36,7 +36,7 @@ export function createRemarkRehypeOptions(locale: IntlLocale) {
 			});
 		},
 		footnoteLabel: t("footnotes"),
-		footnoteLabelProperties: { className: ["sr-only"] },
+		footnoteLabelProperties: { className: [] },
 		footnoteLabelTagName: "h2",
 	} satisfies RemarkRehypeOptions;
 }


### PR DESCRIPTION
currently, the footnote section heading was screen-reader only. this changes that to always display the heading.