### PR TITLE
build: generate production build with webpack not turbopack

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"packageManager": "pnpm@10.21.0",
 	"scripts": {
-		"app:build": "next build",
+		"app:build": "next build --webpack",
 		"app:dev": "next dev --turbopack",
 		"build": "run-s generate:handle content:build generate:api-docs generate:metadata-dump app:build typesense:build",
 		"content:build": "dotenv -c -- tsx ./scripts/content/generate-content.ts build",


### PR DESCRIPTION
this switches the production build back to `webpack` - `turbopack` generates a faulty `keystatic` which crashes. development server is still running fine with `turbopack`.

sidenote: we should improve styling of the global error page.

closes #1631