### PR TITLE
feat: add email link type

### DIFF
--- a/lib/content/keystatic/singletons/index-page.ts
+++ b/lib/content/keystatic/singletons/index-page.ts
@@ -1,6 +1,7 @@
 import { createAssetOptions, createSingleton, withI18nPrefix } from "@acdh-oeaw/keystatic-lib";
 import { fields, singleton } from "@keystatic/core";
 
+import { createLink } from "@/lib/content/keystatic/components/link";
 import { createPreviewUrl } from "@/lib/content/keystatic/utils/create-preview-url";
 
 export const createIndexPage = createSingleton("/index-page/", (paths, locale) => {
@@ -152,7 +153,9 @@ export const createIndexPage = createSingleton("/index-page/", (paths, locale) =
 										image: false,
 										table: false,
 									},
-									components: {},
+									components: {
+										...createLink(paths, locale),
+									},
 								}),
 							},
 							{

--- a/lib/content/keystatic/utils/create-link-schema.ts
+++ b/lib/content/keystatic/utils/create-link-schema.ts
@@ -31,6 +31,10 @@ export function createLinkSchema<TPath extends `/${string}/`>(
 				validation: { isRequired: true },
 				...createAssetOptions(downloadPath),
 			}),
+			email: fields.text({
+				label: "Email",
+				validation: { isRequired: true, pattern: validation.email },
+			}),
 			"resources-events": fields.object({
 				id: fields.relationship({
 					label: "Event",

--- a/lib/content/options.ts
+++ b/lib/content/options.ts
@@ -65,6 +65,7 @@ export const linkKinds = [
 	{ label: "Direct URL", value: "external" },
 	{ label: "Heading identifier", value: "hash" },
 	{ label: "Download", value: "download" },
+	{ label: "Email", value: "email" },
 	{ label: "Events", value: "resources-events" },
 	{ label: "External resources", value: "resources-external" },
 	{ label: "Hosted resources", value: "resources-hosted" },

--- a/lib/content/utils/get-link-props.ts
+++ b/lib/content/utils/get-link-props.ts
@@ -33,6 +33,12 @@ export function getLinkProps(params: LinkSchema) {
 			};
 		}
 
+		case "email": {
+			return {
+				href: `mailto:${params.value}`,
+			};
+		}
+
 		case "external": {
 			return {
 				href: params.value,


### PR DESCRIPTION
this adds a dedicated link type for `email` so we can ensure to add a `mailto:` scheme.