### PR TITLE
docs: document supported languages and line highlight syntax in code blocks

### DIFF
--- a/content/en/documentation/introduction-to-the-dariah-campus-content-management-system/index.mdx
+++ b/content/en/documentation/introduction-to-the-dariah-campus-content-management-system/index.mdx
@@ -283,6 +283,14 @@ console.log('Not highlighted')
 ```
 ````
 
+This will render:
+
+```ts
+console.log('Not highlighted')
+console.log('Highlighted') // [!code highlight]
+console.log('Not highlighted')
+```
+
 To highlight multiple lines:
 
 ````md
@@ -293,6 +301,15 @@ console.log('Highlighted')
 console.log('Not highlighted')
 ```
 ````
+
+This will render:
+
+```ts
+// [!code highlight:2]
+console.log('Highlighted')
+console.log('Highlighted')
+console.log('Not highlighted')
+```
 
 **Table** - Use this icon to add a table. It will show a 3 x 3 table by default, but you can edit this. Do note, though, that larger tables don't work as well on mobile devices.
 

--- a/content/en/documentation/introduction-to-the-dariah-campus-content-management-system/index.mdx
+++ b/content/en/documentation/introduction-to-the-dariah-campus-content-management-system/index.mdx
@@ -245,7 +245,7 @@ From left to right:
   ###
 </Figure>
 
-**Footnote** - this icon allows you to create a footnote.  Click on the icon and type in or paste in your footnote.  This will appear as superscript, but in the published version that text will appear at the very end of the resource as a footnote, and a reference number will appear where you typed this text.
+**Footnote** - this icon allows you to create a footnote. Click on the icon and type in or paste in your footnote. This will appear as superscript, but in the published version that text will appear at the very end of the resource as a footnote, and a reference number will appear where you typed this text.
 
 <Figure src="/assets/content/assets/en/documentation/introduction-to-the-dariah-campus-content-management-system/4.22-footnotes.png" alignment="center">
 
@@ -273,41 +273,19 @@ You can find the supported programming languages [here](https://shiki.style/lang
 
 Highlighting lines or words in code blocks is supported via [special comment syntax](https://shiki.style/packages/transformers#transformernotationhighlight).
 
-To highlight a single line:
+To highlight a line, place a comment at the end of the line:
 
-````md
-```ts
+```
 console.log('Not highlighted')
 console.log('Highlighted') // [!code highlight]
 console.log('Not highlighted')
 ```
-````
 
 This will render:
 
 ```ts
 console.log('Not highlighted')
 console.log('Highlighted') // [!code highlight]
-console.log('Not highlighted')
-```
-
-To highlight multiple lines:
-
-````md
-```ts
-// [!code highlight:2]
-console.log('Highlighted')
-console.log('Highlighted')
-console.log('Not highlighted')
-```
-````
-
-This will render:
-
-```ts
-// [!code highlight:2]
-console.log('Highlighted')
-console.log('Highlighted')
 console.log('Not highlighted')
 ```
 

--- a/content/en/documentation/introduction-to-the-dariah-campus-content-management-system/index.mdx
+++ b/content/en/documentation/introduction-to-the-dariah-campus-content-management-system/index.mdx
@@ -265,9 +265,34 @@ From left to right:
 
 **Code Block** - This is the second of the two 'Code' icons. Use it for longer code examples or instructions that stand on their own like a paragraph. You can set the programming language in the pop-out window that appears in order to enable syntax highlighting. In the example below we set the programming language to 'C'. You then type the code you want to include directly into the 'Code Block' box.
 
-<Figure src="/assets/content/assets/en/documentation/introduction-to-the-dariah-campus-content-management-system/coding-2-image.jpeg" alt="demonstration of the code block option, showing the pop-up window that defines the coding language used (in this case 'C'), and the necessary code for printing the phrase 'hello, world' typed into the code block box." alignment="center">
-  ###
+<Figure src="/assets/content/assets/en/documentation/introduction-to-the-dariah-campus-content-management-system/coding-2-image.jpeg" alt="demonstration of the code block option, showing the pop-up window that defines the coding language used (in this case 'c'), and the necessary code for printing the phrase 'hello, world' typed into the code block box." alignment="center">
+
 </Figure>
+
+You can find the supported programming languages [here](https://shiki.style/languages). Use the value from the `ID` column in the pop-out window.
+
+Highlighting lines or words in code blocks is supported via [special comment syntax](https://shiki.style/packages/transformers#transformernotationhighlight).
+
+To highlight a single line:
+
+````md
+```ts
+console.log('Not highlighted')
+console.log('Highlighted') // [!code highlight]
+console.log('Not highlighted')
+```
+````
+
+To highlight multiple lines:
+
+````md
+```ts
+// [!code highlight:2]
+console.log('Highlighted')
+console.log('Highlighted')
+console.log('Not highlighted')
+```
+````
 
 **Table** - Use this icon to add a table. It will show a 3 x 3 table by default, but you can edit this. Do note, though, that larger tables don't work as well on mobile devices.
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -115,6 +115,8 @@
 
 		/** Don't add backticks around inline `code`. */
 		& code {
+			font-family: var(--font-code);
+
 			&::before {
 				content: unset;
 			}
@@ -305,22 +307,14 @@
 
 /* stylelint-disable number-max-precision */
 
-@layer base {
-	/** @see {@link https://shiki.style/guide/dual-themes#class-based-dark-mode} */
-	[data-ui-color-scheme="dark"] .shiki,
-	[data-ui-color-scheme="dark"] .shiki span {
-		background-color: var(--shiki-dark-bg) !important;
-		color: var(--shiki-dark) !important;
-		font-weight: var(--shiki-dark-font-weight) !important;
-		font-style: var(--shiki-dark-font-style) !important;
-		text-decoration: var(--shiki-dark-text-decoration) !important;
-	}
-
+@layer utilities {
 	/** @see {@link https://shiki.style/packages/transformers} */
-	.shiki {
-		& .line.higlighted {
+	pre.shiki code {
+		font-family: var(--font-code);
+
+		& .line.highlighted {
 			display: inline-block;
-			width: calc(100% + 48px);
+			width: calc(100% + 2 * 1.14286em);
 			margin-inline: -1.14286em;
 			padding-inline: 1.14286em;
 			background-color: #0000000d;


### PR DESCRIPTION
this documents which programming languages support syntax highlighting in our code block widget, and how to create line highlights with special comment syntax.

closes #1642
