### PR TITLE
build: drop node.js v22, use v24 lts everywhere

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Next.js",
-	"image": "ghcr.io/acdh-oeaw/devcontainer-frontend:22",
+	"image": "ghcr.io/acdh-oeaw/devcontainer-frontend:24",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
         os: [ubuntu-24.04]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"type": "module",
 	"engines": {
-		"node": "^22 || ^24"
+		"node": "^24"
 	},
 	"devEngines": {
 		"runtime": {
@@ -13,7 +13,7 @@
 			"onFail": "download"
 		}
 	},
-	"packageManager": "pnpm@10.22.0",
+	"packageManager": "pnpm@10.23.0",
 	"scripts": {
 		"app:build": "next build --webpack",
 		"app:dev": "next dev --turbopack",


### PR DESCRIPTION
vercel (aws) has added support for node.js v24 (LTS) as runtime so we can switch to it (already enabled in vercel dashboard).