### PR TITLE
fix: unwrap gfm autolink literals

### DIFF
--- a/lib/content/collections/curricula.ts
+++ b/lib/content/collections/curricula.ts
@@ -18,6 +18,7 @@ import {
 	createFootnotesPlugin,
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { getImageDimensions } from "@/lib/content/utils/get-image-dimensions";
@@ -28,6 +29,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createFootnotesPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],

--- a/lib/content/collections/documentation.ts
+++ b/lib/content/collections/documentation.ts
@@ -18,6 +18,7 @@ import {
 	createFootnotesPlugin,
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { defaultLocale, getIntlLanguage } from "@/lib/i18n/locales";
@@ -27,6 +28,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createFootnotesPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],

--- a/lib/content/collections/people.ts
+++ b/lib/content/collections/people.ts
@@ -7,6 +7,7 @@ import { compile, type CompileOptions } from "@/lib/content/mdx/compile";
 import {
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { getImageDimensions } from "@/lib/content/utils/get-image-dimensions";
@@ -17,6 +18,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],
 	remarkRehypeOptions: createRemarkRehypeOptions(locale),

--- a/lib/content/collections/resources/events.ts
+++ b/lib/content/collections/resources/events.ts
@@ -18,6 +18,7 @@ import {
 	createFootnotesPlugin,
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { getImageDimensions } from "@/lib/content/utils/get-image-dimensions";
@@ -28,6 +29,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createFootnotesPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],

--- a/lib/content/collections/resources/external.ts
+++ b/lib/content/collections/resources/external.ts
@@ -18,6 +18,7 @@ import {
 	createFootnotesPlugin,
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { getImageDimensions } from "@/lib/content/utils/get-image-dimensions";
@@ -28,6 +29,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createFootnotesPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],

--- a/lib/content/collections/resources/hosted.ts
+++ b/lib/content/collections/resources/hosted.ts
@@ -18,6 +18,7 @@ import {
 	createFootnotesPlugin,
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { getImageDimensions } from "@/lib/content/utils/get-image-dimensions";
@@ -28,6 +29,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createFootnotesPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],

--- a/lib/content/collections/resources/pathfinders.ts
+++ b/lib/content/collections/resources/pathfinders.ts
@@ -18,6 +18,7 @@ import {
 	createFootnotesPlugin,
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { getImageDimensions } from "@/lib/content/utils/get-image-dimensions";
@@ -28,6 +29,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createFootnotesPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],

--- a/lib/content/collections/sources.ts
+++ b/lib/content/collections/sources.ts
@@ -7,6 +7,7 @@ import { compile, type CompileOptions } from "@/lib/content/mdx/compile";
 import {
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { getImageDimensions } from "@/lib/content/utils/get-image-dimensions";
@@ -17,6 +18,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],
 	remarkRehypeOptions: createRemarkRehypeOptions(locale),

--- a/lib/content/collections/tags.ts
+++ b/lib/content/collections/tags.ts
@@ -7,6 +7,7 @@ import { compile, type CompileOptions } from "@/lib/content/mdx/compile";
 import {
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { defaultLocale, getIntlLanguage } from "@/lib/i18n/locales";
@@ -16,6 +17,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],
 	remarkRehypeOptions: createRemarkRehypeOptions(locale),

--- a/lib/content/github-client/index.ts
+++ b/lib/content/github-client/index.ts
@@ -31,6 +31,7 @@ import {
 	createFootnotesPlugin,
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import type { Client } from "@/lib/content/types";
@@ -42,6 +43,7 @@ const createEvaluateOptions = (baseUrl: string) => {
 	return {
 		remarkPlugins: [
 			createGitHubMarkdownPlugin(),
+			createUnwrappedAutolinkLiteralsPlugin(),
 			createFootnotesPlugin(),
 			createTypographicQuotesPlugin(getIntlLanguage(locale)),
 		],

--- a/lib/content/mdx/remark-plugins.ts
+++ b/lib/content/mdx/remark-plugins.ts
@@ -5,10 +5,15 @@ import withGfm from "remark-gfm";
 import withTypographicQuotes from "remark-smartypants";
 import type { Pluggable } from "unified";
 
+import { withUnwrappedAutolinkLiterals } from "@/lib/content/mdx/with-unwrapped-autolink-literals";
 import type { IntlLanguage } from "@/lib/i18n/locales";
 
 export function createGitHubMarkdownPlugin() {
 	return withGfm satisfies Pluggable;
+}
+
+export function createUnwrappedAutolinkLiteralsPlugin() {
+	return withUnwrappedAutolinkLiterals satisfies Pluggable;
 }
 
 export function createFootnotesPlugin() {

--- a/lib/content/mdx/with-unwrapped-autolink-literals.ts
+++ b/lib/content/mdx/with-unwrapped-autolink-literals.ts
@@ -1,0 +1,26 @@
+import type { Root } from "mdast";
+import type { Plugin } from "unified";
+import { SKIP, visit } from "unist-util-visit";
+
+export const withUnwrappedAutolinkLiterals: Plugin<[], Root> =
+	function withUnwrappedAutolinkLiterals() {
+		return function transformer(tree) {
+			visit(tree, (node) => {
+				if (
+					node.type === "mdxJsxTextElement" &&
+					node.name === "Link" &&
+					node.children.length === 1
+				) {
+					const [child] = node.children;
+
+					if (child?.type === "link") {
+						node.children = child.children;
+
+						return SKIP;
+					}
+				}
+
+				return undefined;
+			});
+		};
+	};

--- a/lib/content/singletons/index-page.ts
+++ b/lib/content/singletons/index-page.ts
@@ -7,6 +7,7 @@ import { compile, type CompileOptions } from "@/lib/content/mdx/compile";
 import {
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { getImageDimensions } from "@/lib/content/utils/get-image-dimensions";
@@ -17,6 +18,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],
 	remarkRehypeOptions: createRemarkRehypeOptions(locale),

--- a/lib/content/singletons/legal-notice.ts
+++ b/lib/content/singletons/legal-notice.ts
@@ -9,6 +9,7 @@ import { compile, type CompileOptions } from "@/lib/content/mdx/compile";
 import {
 	createGitHubMarkdownPlugin,
 	createTypographicQuotesPlugin,
+	createUnwrappedAutolinkLiteralsPlugin,
 } from "@/lib/content/mdx/remark-plugins";
 import { createRemarkRehypeOptions } from "@/lib/content/mdx/remark-rehype-options";
 import { defaultLocale, getIntlLanguage } from "@/lib/i18n/locales";
@@ -18,6 +19,7 @@ const locale = defaultLocale;
 const compileOptions: CompileOptions = {
 	remarkPlugins: [
 		createGitHubMarkdownPlugin(),
+		createUnwrappedAutolinkLiteralsPlugin(),
 		createTypographicQuotesPlugin(getIntlLanguage(locale)),
 	],
 	remarkRehypeOptions: createRemarkRehypeOptions(locale),


### PR DESCRIPTION
github flavored markdown (gfm) supports ["autolink literals"](https://github.github.com/gfm/#extended-email-autolink), which turn plaintext which looks like a url or email address into html anchor elements.

our mdx processing pipeline supports this feature as well via the [`remark-gfm` plugin](https://github.com/micromark/micromark-extension-gfm-autolink-literal).

however, when using our custom `<Link>` component, this can lead to double nested anchor elements: basically in `<Link kind="email" href="info@dariah.eu">info@dariah.eu</Link>` the text content is treated as an autolink literal, which leads to `<Link kind="email" href="info@dariah.eu"><a href="mailto:info@dariah.eu">info@dariah.eu</a></Link>`.

this pr adds a remark plugin to the mdx processing pipeline to unwrap added anchor elements when they are the single child of a `<Link>`.