### PR TITLE
feat: show all possible facet values

### DIFF
--- a/app/(app)/(default)/search/_components/search-facets.tsx
+++ b/app/(app)/(default)/search/_components/search-facets.tsx
@@ -29,6 +29,8 @@ export function SearchFacets(props: Readonly<SearchFacetsProps>): ReactNode {
 		attribute,
 		limit: 15,
 		showMore: true,
+		/** Default is 20. */
+		showMoreLimit: 500,
 	});
 
 	return (

--- a/app/(app)/(default)/search/_components/search-facets.tsx
+++ b/app/(app)/(default)/search/_components/search-facets.tsx
@@ -29,7 +29,6 @@ export function SearchFacets(props: Readonly<SearchFacetsProps>): ReactNode {
 		attribute,
 		limit: 15,
 		showMore: true,
-		showMoreLimit: 25,
 	});
 
 	return (


### PR DESCRIPTION
currently we restrict the number of displayed facet values on the search page after clicking "show more" to 25. this bumps that value to 500 (not setting it falls back to the default of 20)

closes #1695