### PR TITLE
fix: adjust video id field validation to accept slashes

### DIFF
--- a/lib/content/keystatic/validation.ts
+++ b/lib/content/keystatic/validation.ts
@@ -24,6 +24,6 @@ export const urlSearchParamsOptional = {
 };
 
 export const videoId = {
-	regex: /^[\w-]+$/,
+	regex: /^(?!https?:\/\/)/,
 	message: "Must only include the 'id', not the full URL.",
 };


### PR DESCRIPTION
this relaxes the video id field validation to accept nakala ids (which include slashes). the motivation for field validation was only to prevent users posting full youtube urls.

closes #1713