### PR TITLE
feat: add additional fields to api responses for external resources

### DIFF
--- a/scripts/api/generate-metadata-dump.ts
+++ b/scripts/api/generate-metadata-dump.ts
@@ -135,8 +135,10 @@ export async function createMetadata(): Promise<{
 		await Promise.all(
 			(await client.collections[name].all()).map(async (item) => {
 				const isDraft = "draft" in item.metadata && item.metadata.draft === true;
+
 				if (isDraft) return;
-				resources.push({
+
+				const resource = {
 					id: item.id,
 					collection: name,
 					kind,
@@ -168,7 +170,22 @@ export async function createMetadata(): Promise<{
 					"dariah-working-groups": item.metadata["dariah-working-groups"].map(createWorkingGroup),
 					domain: sharedMetadata.domain,
 					"target-group": sharedMetadata["target-group"],
-				});
+				};
+
+				if (kind === "external") {
+					const external = await client.collections.resourcesExternal.get(item.id);
+					assert(external);
+
+					resources.push({
+						...resource,
+						external: {
+							"publication-date": external.metadata.remote["publication-date"],
+							url: external.metadata.remote.url,
+						},
+					} as ResourceMetadata);
+				} else {
+					resources.push(resource as ResourceMetadata);
+				}
 			}),
 		);
 	}

--- a/scripts/api/metadata-schemas.ts
+++ b/scripts/api/metadata-schemas.ts
@@ -29,15 +29,8 @@ export const curriculumMetadataSchema = v.object({
 
 export type CurriculumMetadata = v.InferOutput<typeof curriculumMetadataSchema>;
 
-export const resourceMetadataSchema = v.object({
+const baseResourceFields = {
 	id: v.string(),
-	collection: v.picklist([
-		"resourcesEvents",
-		"resourcesExternal",
-		"resourcesHosted",
-		"resourcesPathfinders",
-	]),
-	kind: v.picklist(["event", "external", "hosted", "pathfinder"]),
 	version: v.string(),
 	pid: v.string(),
 	title: v.string(),
@@ -64,6 +57,46 @@ export const resourceMetadataSchema = v.object({
 		v.array(v.object({ slug: v.string(), "sshoc-marketplace-id": v.string() })),
 		[],
 	),
+};
+
+const eventResourceSchema = v.object({
+	...baseResourceFields,
+	collection: v.literal("resourcesEvents"),
+	kind: v.literal("event"),
 });
+
+const externalResourceSchema = v.object({
+	...baseResourceFields,
+	collection: v.literal("resourcesExternal"),
+	kind: v.literal("external"),
+	external: v.object({
+		url: v.string(),
+		"publication-date": v.string(),
+	}),
+});
+
+const hostedResourceSchema = v.object({
+	...baseResourceFields,
+	collection: v.literal("resourcesHosted"),
+	kind: v.literal("hosted"),
+});
+
+const pathfinderResourceSchema = v.object({
+	...baseResourceFields,
+	collection: v.literal("resourcesPathfinders"),
+	kind: v.literal("pathfinder"),
+});
+
+export const resourceMetadataSchema = v.variant("kind", [
+	eventResourceSchema,
+	externalResourceSchema,
+	hostedResourceSchema,
+	pathfinderResourceSchema,
+]);
+
+export type EventResourceMetadata = v.InferOutput<typeof eventResourceSchema>;
+export type ExternalResourceMetadata = v.InferOutput<typeof externalResourceSchema>;
+export type HostedResourceMetadata = v.InferOutput<typeof hostedResourceSchema>;
+export type PathfinderResourceMetadata = v.InferOutput<typeof pathfinderResourceSchema>;
 
 export type ResourceMetadata = v.InferOutput<typeof resourceMetadataSchema>;


### PR DESCRIPTION
- adds `external.url` and `external.publication-date` fields to api responses for external resources
- refactors resource metadata schema to use discriminated unions (so we can add additional fields per resource kind)

x-ref https://github.com/SSHOC/SSHOMP-Ingest/issues/40#issuecomment-4266205750