### PR TITLE
feat: add pr instead of pushing to main when minting handle pid

### DIFF
--- a/scripts/handle/create-handle.sh
+++ b/scripts/handle/create-handle.sh
@@ -5,7 +5,23 @@ if [[ ${VERCEL_ENV} != "production" || ${VERCEL_GIT_COMMIT_REF} != "main" ]]; th
 	exit 0
 fi
 
+branch="content/add-handle-${VERCEL_GIT_COMMIT_SHA:0:12}"
+repo="${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}"
+
 files=$(git diff --diff-filter=AMR --name-only ${VERCEL_GIT_PREVIOUS_SHA} ${VERCEL_GIT_COMMIT_SHA} -- 'content/*/curricula/**/index.mdx' 'content/*/resources/**/index.mdx' | xargs)
+
+if [[ -n "${files}" ]]; then
+  existing_pr=$(curl --fail --silent \
+    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "Accept: application/vnd.github+json" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/${repo}/pulls?head=${VERCEL_GIT_REPO_OWNER}:${branch}&base=main&state=open")
+
+  if [[ "${existing_pr}" != "[]" ]]; then
+    echo "Pull request already exists for ${branch}."
+    exit 0
+  fi
+fi
 
 for file in $files; do
   echo "Processing ${file}..."
@@ -16,18 +32,31 @@ for file in $files; do
 done
 
 if [[ -n "$(git diff --staged)" ]]; then
-  echo "Pushing changes to github..."
+  echo "Pushing changes to github pull request..."
 
-  if ! git remote | grep -q origin; then
-    git remote add origin https://$GITHUB_TOKEN@github.com/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG.git
+  origin="https://${GITHUB_TOKEN}@github.com/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}.git"
+
+  if git remote | grep -q origin; then
+    git remote set-url origin "${origin}"
+  else
+    git remote add origin "${origin}"
   fi
 
   git config user.name "${GITHUB_USERNAME}"
   git config user.email "${GITHUB_EMAIL}"
 
+  title="content: add handle"
+  body="Adds generated handle metadata for content changed in ${VERCEL_GIT_COMMIT_SHA}."
+
   git add -A
   git commit -m "content: add handle [skip ci]"
-  git push origin HEAD:main
+  git push --force-with-lease origin "HEAD:${branch}"
+
+  curl --fail --silent --show-error \
+    --request POST \
+    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "Accept: application/vnd.github+json" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    --data "{\"title\":\"${title}\",\"head\":\"${branch}\",\"base\":\"main\",\"body\":\"${body}\"}" \
+    "https://api.github.com/repos/${repo}/pulls"
 fi
-
-


### PR DESCRIPTION
currently, the handle pid script mints an id, saves it to the mdx file, git commits, and pushes the changes directly to the main branch. this however does not work with branch protection enabled (unless we want to allow bypassing protections). this changes the script to open a pull request with the changes instead. 