### PR TITLE
fix: don't mint handles for external resources

### DIFF
--- a/components/resource-metadata.tsx
+++ b/components/resource-metadata.tsx
@@ -1,3 +1,4 @@
+import { isNonEmptyString } from "@acdh-oeaw/lib";
 import { useFormatter, useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 
@@ -117,7 +118,7 @@ export function ResourceMetadata(props: Readonly<ResourceMetadataProps>): ReactN
 					<dt>{t("version")}:</dt>
 					<dd>{version}</dd>
 				</div>
-				{doi != null ? (
+				{isNonEmptyString(doi) ? (
 					<div className="flex gap-x-1.5">
 						<dt>{t("pid")}:</dt>
 						<dd>

--- a/content/en/resources/external/a-digital-scholarly-edition-of-intellectual-berlin-around-1800/index.mdx
+++ b/content/en/resources/external/a-digital-scholarly-edition-of-intellectual-berlin-around-1800/index.mdx
@@ -24,7 +24,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-2a13-7753-afd4-6fbbede9f1f2
 ---
 This video features Anne Baillot (Centre Marc Bloch, Berlin) talking about the Digital Edition 'Letters and Texts: Intellectual Berlin around 1800'. This online digital edition presents texts from 1800 to 1830 that were, until this day, either completely unpublished or published in an abridged form. This work is funded by the German Research Foundation.
 

--- a/content/en/resources/external/an-editorial-and-technical-journey-into-post-publication-peer-review-pppr/index.mdx
+++ b/content/en/resources/external/an-editorial-and-technical-journey-into-post-publication-peer-review-pppr/index.mdx
@@ -28,7 +28,6 @@ content-type: video
 translations: []
 dariah-national-consortia:
   - fr
-doi: https://hdl.handle.net/21.11159/019595c4-2b6f-718a-9f33-64b3df6c6c74
 ---
 As part of the DARIAH In-House Webinar sessions, the 'Friday Frontiers' programme included a presentation on Post-Publication Peer Review (PPPR) from former President of the DARIAH Board of Directors, Laurent Romary.
 

--- a/content/en/resources/external/an-introduction-to-conceptual-modelling/index.mdx
+++ b/content/en/resources/external/an-introduction-to-conceptual-modelling/index.mdx
@@ -21,7 +21,6 @@ remote:
   publication-date: 2017-03-14
   url: https://teach.dariah.eu/course/view.php?id=31
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-2b9e-7726-819a-2b8ae9df4243
 ---
 This workshop introduces the basics of conceptual modelling and ontologies. We discuss the principles and techniques that can be used in order to formulate the knowledge we have about a specific domain in such a way that it can be understood and used in reasoning tasks by both humans and machines. The nature and role of models is reviewed. Focusing on conceptual models, we present the building blocks and mechanisms used to create them. Some frequent modelling issues and usual practices addressing them are discussed. Step-by-step examples are given, as well as a small set of assignments for personal practice. An introduction to ontologies as a kind of models supporting data access, integration, interoperability and application development, along with a short overview of CIDOC CRM as an exemplar ontology for the cultural domain, finish off the workshop.
 

--- a/content/en/resources/external/analyzing-multilingual-french-and-russian-text-using-nltk-spacy-and-stanza/index.mdx
+++ b/content/en/resources/external/analyzing-multilingual-french-and-russian-text-using-nltk-spacy-and-stanza/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2024-11-13
   url: https://doi.org/10.46430/phen0121
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-2bd8-748d-8cea-4cd9d770b7b6
 ---
 Many of the resources available for learning computational methods of text analysis focus on English-language texts and corpora, and often lack the information which is needed to work with non-English source material. To help remedy this, this lesson will provide an introduction to analyzing non-English and multilingual text (that is, text written in more than one language) using Python. Using a multilingual text composed of Russian and French, this lesson will show how you can use computational methods to perform three fundamental preprocessing tasks: tokenization, part-of-speech tagging, and lemmatization. Then, it will teach you to automatically detect the languages present in a preprocessed text.
 

--- a/content/en/resources/external/boost-your-ehumanities-and-eheritage-research-with-research-infrastructures/index.mdx
+++ b/content/en/resources/external/boost-your-ehumanities-and-eheritage-research-with-research-infrastructures/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2018-04-24
   url: https://training.parthenos-project.eu/sample-page/ehumanities-eheritage-webinar-series/webinar-boost-your-ehumanities-and-eheritage-research-with-research-infrastructures/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-2c68-707a-9541-b4287665bfa2
 ---
 This is a record of a webinar dedicated to the phase of the research life cycle "Develop Research Questions". It dives into details of the topic of developing research questions with RIs, especially on finding, working with and contributing data to RI collections, using Virtual Research Environments, and tools. It shows successful examples of how Digital Humanities and eHeritage approaches, in cooperation with relevant Research Infrastructures, lead to innovative research methods and questions.
 

--- a/content/en/resources/external/born-digital-research-in-the-humanities-course/index.mdx
+++ b/content/en/resources/external/born-digital-research-in-the-humanities-course/index.mdx
@@ -36,7 +36,6 @@ remote:
   publisher: RESHAPED, School of Advanced Study, University of London
 content-type: training-module
 translations: []
-doi: https://hdl.handle.net/21.11159/019a0245-954f-7055-9132-8cf37412552f
 ---
 This free online course is designed to equip humanities researchers and practitioners at all career stages with the knowledge needed to engage with the new research challenges and opportunities associated with the rapid expansion of born-digital materials and archives in the 21st century. The course will introduce key concepts associated with digital culture and born-digital archives and provide an overview of key ethical and legal issues involved in born-digital research. The course also includes a range of research examples and hands-on activities that will provide researchers with a critical and practical understanding of different methods and approaches for collecting and analysing born-digital materials. 
 

--- a/content/en/resources/external/chroma-key-tutorial/index.mdx
+++ b/content/en/resources/external/chroma-key-tutorial/index.mdx
@@ -24,7 +24,6 @@ remote:
   publication-date: 2024-01-29
   url: https://play.lnu.se/media/t/0_c8n3sfbv
   publisher: LNU Play
-doi: https://hdl.handle.net/21.11159/019595c4-2ca3-743f-81aa-c08284b9e3b6
 dariah-national-consortia:
   - se
 ---

--- a/content/en/resources/external/citizen-science-in-the-digital-arts-and-humanities/index.mdx
+++ b/content/en/resources/external/citizen-science-in-the-digital-arts-and-humanities/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2019-10-04
   url: https://training.parthenos-project.eu/sample-page/citizen-science-in-the-digital-arts-and-humanities/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-2cdc-761f-8f1c-81358c928c93
 ---
 This module looks at the variety of practices within 'citizen science', how you as a humanist might get started working with them, what issues you might be wary of along the way and how Research Infrastructures can potentially help you.
 

--- a/content/en/resources/external/clustering-and-visualising-documents-using-word-embeddings/index.mdx
+++ b/content/en/resources/external/clustering-and-visualising-documents-using-word-embeddings/index.mdx
@@ -30,7 +30,6 @@ remote:
   publication-date: 2023-08-09
   url: https://doi.org/10.46430/phen0111
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-2d11-7399-a5f6-32bd649d2d36
 ---
 As corpora are increasingly 'born digital' on hard drives as well as web and email servers, we are moving from being able to select or group documents using keyword or manual searches to needing to be able to automate this task at scale. Moreover, large-ish, unlabelled corpora of thousands or tens-of-thousands of documents are not particularly well-suited to topic modelling or TF/IDF analysis either. Since we don't have a sense of what kinds of groups might exist, what kinds of topics might be covered, or what level of distinctiveness in vocabulary might matter, we need different, more flexible ways to visualise and extract structure from texts.
 

--- a/content/en/resources/external/computer-vision-for-the-humanities-an-introduction-to-deep-learning-for-image-classification-part-1/index.mdx
+++ b/content/en/resources/external/computer-vision-for-the-humanities-an-introduction-to-deep-learning-for-image-classification-part-1/index.mdx
@@ -33,7 +33,6 @@ remote:
   publication-date: 2022-08-17
   url: https://doi.org/10.46430/phen0101
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-2d4a-74d9-8c78-08852b58fd9a
 dariah-national-consortia:
   - nl
 ---

--- a/content/en/resources/external/computer-vision-for-the-humanities-an-introduction-to-deep-learning-for-image-classification-part-2/index.mdx
+++ b/content/en/resources/external/computer-vision-for-the-humanities-an-introduction-to-deep-learning-for-image-classification-part-2/index.mdx
@@ -34,7 +34,6 @@ remote:
   publication-date: 2022-08-17
   url: https://doi.org/10.46430/phen0102
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-2d87-76ff-85d3-6660953c7978
 dariah-national-consortia:
   - nl
 ---

--- a/content/en/resources/external/copyright-of-3d-data/index.mdx
+++ b/content/en/resources/external/copyright-of-3d-data/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2024-07-09
   url: https://culturedigitalskills.github.io/2024-copyright-data
   publisher: Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-2db6-744c-9afb-c42466beee39
 ---
 This resource offers an introduction to copyright within the UK context when dealing with multidimensional media. It introduces the UK context for copyright, which is a legal right, protecting the copyright owner and/or the creator of a work giving them control over their work and how it is used.  Learners are presented with information that has been gathered from a mixture of web resources, references and links, including the British Library, JISC, and Creative Commons.
 

--- a/content/en/resources/external/corpus-analysis-with-spacy/index.mdx
+++ b/content/en/resources/external/corpus-analysis-with-spacy/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2023-11-02
   url: https://doi.org/10.46430/phen0113
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-2de2-70e8-8265-d9f6f1857f0f
 ---
 Say you have a big collection of texts. Maybe you've gathered speeches from the French Revolution, compiled a bunch of Amazon product reviews, or unearthed a collection of diary entries written during the first world war. In any of these cases, computational analysis can be a good way to compliment close reading of your corpus... but where should you start?
 

--- a/content/en/resources/external/create-impact-with-your-e-humanities-and-e-heritage-research/index.mdx
+++ b/content/en/resources/external/create-impact-with-your-e-humanities-and-e-heritage-research/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2018-02-08
   url: https://training.parthenos-project.eu/sample-page/ehumanities-eheritage-webinar-series/webinar-impact/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-2e0e-72af-a450-3f1c3dbea557
 ---
 This is a record of a webinar dedicated to the phase of the Research Lifecycle "Publish Results". It covers several aspects related to successfully drafting and implementing a publication and dissemination strategy taking into account specific Research Infrastructural aspects. It first covers the basics of impact measurement and research metrics, both from the individual researcher's perspective as well as the Research Infrastructure perspective since these are strongly interlinked. It then goes into details such as repositories, new publication types and new forms of dissemination (such as blogs or wikis) and touches upon challenges such as data and software citation. It specifically introduces the Impactomatrix as a tool for drafting an impact-orientated publication and dissemination strategy.
 

--- a/content/en/resources/external/creating-deep-convolutional-neural-networks-for-image-classification/index.mdx
+++ b/content/en/resources/external/creating-deep-convolutional-neural-networks-for-image-classification/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2023-03-23
   url: https://doi.org/10.46430/phen0108
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-2e4b-729c-a63d-2152db547a68
 ---
 This lesson provides a beginner-friendly introduction to convolutional neural networks, which along with transformers, are frequently-used machine learning models for image classification. Neural networks develop their own idiosyncratic ways of seeing and often fail to separate features in the ways we might expect. Understanding how these networks operate provides us with a way to explore their limitations when programmed to identify images they have not been trained to recognize.
 

--- a/content/en/resources/external/creating-guis-in-python-for-digital-humanities-projects/index.mdx
+++ b/content/en/resources/external/creating-guis-in-python-for-digital-humanities-projects/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2023-03-23
   url: https://doi.org/10.46430/phen0107
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-2e80-73fc-81cb-2a5f86c093b5
 ---
 This lesson demonstrates how to implement a Graphical User Interface (GUI) using Python. A GUI is an expected feature of most modern applications, but many users lack the necessary computing skills to execute Python scripts or operate terminal/command line applications. Distributing applications that use GUIs helps support the greatest number of other historians to benefit from the applications you develop. This tutorial focuses on the three steps involved in creating modern-looking and useable applications: designing a GUI, implementing a GUI within an application, and creating an executable file to distribute the application.
 

--- a/content/en/resources/external/creating-interactive-visualizations-with-plotly/index.mdx
+++ b/content/en/resources/external/creating-interactive-visualizations-with-plotly/index.mdx
@@ -25,7 +25,6 @@ remote:
   publication-date: 2023-12-13
   url: https://doi.org/10.46430/phen0115
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-2eb7-750b-91d7-52dbf3acf96d
 ---
 Plotly is a company which provides a number of open-source libraries allowing users to build interactive graphs. Unlike static images, Plotly graphs can respond to user actions with popup labels, pan-and-zoom abilities, faceted data displays, and more. Plotly libraries are available in Python — the focus of this tutorial — as well as various programming languages, including R and Julia. A wide variety of graphs is available through Plotly libraries, ranging from the statistical or scientific to the financial or geographic. These graphs can be displayed using various methods, including Jupyter notebooks, HTML files, and web applications produced with Plotly's Dash framework.
 

--- a/content/en/resources/external/creating-stories-with-3d-data-on-the-web/index.mdx
+++ b/content/en/resources/external/creating-stories-with-3d-data-on-the-web/index.mdx
@@ -32,7 +32,6 @@ remote:
   publication-date: 2024-07-09
   url: https://culturedigitalskills.github.io/2024-storytelling-3d-data/
   publisher: Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-2eee-772b-b2cd-03f085808907
 ---
 This resource provides guidance on how to use digital storytelling, deploying 3D data, annotations and combining media to enable users to access and explore information about digital heritage assets over the web.
 

--- a/content/en/resources/external/crowdsourcing-methods-with-cultural-heritage-and-academic-datasets/index.mdx
+++ b/content/en/resources/external/crowdsourcing-methods-with-cultural-heritage-and-academic-datasets/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2021-03-22
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-ch-lecture-62
   publisher: Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)
-doi: https://hdl.handle.net/21.11159/019595c4-2f24-73be-8658-5c9cd274b6bb
 dariah-national-consortia:
   - at
 ---

--- a/content/en/resources/external/cultural-heritage-some-observations-on-collecting-and-curating-in-the-digital-age/index.mdx
+++ b/content/en/resources/external/cultural-heritage-some-observations-on-collecting-and-curating-in-the-digital-age/index.mdx
@@ -32,7 +32,6 @@ remote:
   publication-date: 2018-06-15
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-lecture-33
   publisher: Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)
-doi: https://hdl.handle.net/21.11159/019595c4-2f5b-7165-bbf8-32c3373a5efd
 dariah-national-consortia:
   - at
 ---

--- a/content/en/resources/external/dariah-de-collection-registry-tutorial/index.mdx
+++ b/content/en/resources/external/dariah-de-collection-registry-tutorial/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2018-01-01
   url: https://dfa.de.dariah.eu/doc/colreg/
   publisher: DARIAH-DE
-doi: https://hdl.handle.net/21.11159/019595c4-2f92-77d9-9f09-f908629bee72
 ---
 If you are searching for a tool that enables you to describe and index data collections, the DARIAH-DE Collection Registry might be the perfect one for you. In the Collection Registry you can describe collections with metadata, using the DARIAH Collection Description Data Model (DCDDM). Via a graphical user interface, you can describe your collections in different categories, depending on the metadata you have available. Not only digital collections but also analogous collections can be described.
 

--- a/content/en/resources/external/dariah-de-publikator-tutorial/index.mdx
+++ b/content/en/resources/external/dariah-de-publikator-tutorial/index.mdx
@@ -33,7 +33,6 @@ remote:
   publication-date: 2019-12-01
   url: https://repository.de.dariah.eu/doc/services/submodules/publikator/docs/index.html
   publisher: DARIAH-DE
-doi: https://hdl.handle.net/21.11159/019595c4-2fca-725f-8a15-65f5ede87e64
 dariah-national-consortia:
   - de
 ---

--- a/content/en/resources/external/data-analysis-with-python/index.mdx
+++ b/content/en/resources/external/data-analysis-with-python/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2023-05-22
   url: https://teach.dariah.eu/course/view.php?id=72
   publisher: dariahTeach
-doi: https://hdl.handle.net/21.11159/019595c4-2fff-75bf-ba28-cdd6ad5afd7e
 ---
 Analytics has a strong tradition, very established methods, and a broad range of applications in culture, economy, and society. Social media analytics extends general analytics toward analysing social (media) relationships. Cultural analytics builds on successful analytical methods and applies its techniques and methods to studying cultural objects.
 

--- a/content/en/resources/external/data-ethics-in-cultural-heritage/index.mdx
+++ b/content/en/resources/external/data-ethics-in-cultural-heritage/index.mdx
@@ -35,7 +35,6 @@ remote:
   publication-date: 2024-07-09
   url: https://culturedigitalskills.github.io/2024-ethics-data/
   publisher: Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-3031-7320-b493-d3b8e5de89ed
 ---
 This resource aims to introduce the main aspects of data ethics in the cultural heritage domain. It also examines how data management can be supported to become more ethical, while also addressing topical discourse about data ethics in the sector. The resource also aims to support in critically reflecting on some case studies with evident digital data ethics considerations.
 

--- a/content/en/resources/external/david-boder-from-wire-recordings-to-website/index.mdx
+++ b/content/en/resources/external/david-boder-from-wire-recordings-to-website/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2018-10-18
   url: https://ranke2.uni.lu/u/boder/
   publisher: ranke2lu
-doi: https://hdl.handle.net/21.11159/019595c4-3061-761b-a634-c2062d3faa1f
 dariah-national-consortia:
   - lu
 ---

--- a/content/en/resources/external/design-development-and-deployment-of-augmented-reality-applications/index.mdx
+++ b/content/en/resources/external/design-development-and-deployment-of-augmented-reality-applications/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2023-05-22
   url: https://teach.dariah.eu/course/view.php?id=77
   publisher: dariahTeach
-doi: https://hdl.handle.net/21.11159/019595c4-3095-76e1-9193-c977fc3261a1
 dariah-national-consortia:
   - se
 ---

--- a/content/en/resources/external/designing-a-deck-of-timeline-cards-for-tabletops-and-tabletop-simulator/index.mdx
+++ b/content/en/resources/external/designing-a-deck-of-timeline-cards-for-tabletops-and-tabletop-simulator/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2024-03-18
   url: https://doi.org/10.46430/phen0118
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-30cd-737e-ab5c-4325c5d383e9
 ---
 Just as authors or publishers use word processors to create printed books, designers of tabletop games regularly use digital tools to create paper prototypes of their work. This tutorial will introduce you to two of these specialized digital tools: Andrea Nini's nanDECK and Tabletop Simulator.
 

--- a/content/en/resources/external/digital-approaches-to-textual-analysis-course/index.mdx
+++ b/content/en/resources/external/digital-approaches-to-textual-analysis-course/index.mdx
@@ -31,7 +31,6 @@ remote:
   publisher: RESHAPED, School of Advanced Study, University of London
 content-type: training-module
 translations: []
-doi: https://hdl.handle.net/21.11159/019a074a-497b-724d-b302-3a872d0a2db5
 ---
 Have you ever wondered how digital technologies could help with the analysis of texts whether it is a single text or a large corpora? Rapid developments in the field mean that these technologies are easier to use and more readily available than ever before. This free online course provides a practical introduction to working with digital texts and applying some of the tools available to digitise and interrogate them. The course is divided into the three strands: Core Concepts, Applications and Workflows; Preparing Texts for Analysis; and Analysing Digital Texts. It will help you to decide whether and how to use digital approaches to textual analysis and to select the correct tools for your research project. 
 

--- a/content/en/resources/external/digital-exhibition-design/index.mdx
+++ b/content/en/resources/external/digital-exhibition-design/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2023-11-28
   url: https://universityofbrighton.github.io/2023-exhibition-design/
   publisher: Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-3106-734f-aea5-5be9e29bcb2a
 ---
 This resource provides guidance on digital practices to curate interactive experiences through a set of practical exercises. The resource aims to support GLAM's researchers and practitioners to engage with their audiences through the design of multimedia applications, while making use of appropriate frameworks and tools.
 

--- a/content/en/resources/external/digital-historical-research-on-european-historical-newspaper-with-newseye-platform/index.mdx
+++ b/content/en/resources/external/digital-historical-research-on-european-historical-newspaper-with-newseye-platform/index.mdx
@@ -33,7 +33,6 @@ remote:
   publication-date: 2023-05-22
   url: https://teach.dariah.eu/course/view.php?id=71
   publisher: DARIAH Teach
-doi: https://hdl.handle.net/21.11159/019595c4-313c-7205-bfc5-c1223df0f6e1
 ---
 Newspapers collect information about cultural, political and social events in a more detailed way than any other public record. Since their beginnings in the 17th century, they have recorded billions of events, stories and personal names in almost every language and every country daily. The importance of historical newspapers as cultural heritage is well understood. However, the recent progress of dedicated projects such as the H2020 NewsEye project ([https://www.newseye.eu/](https://www.newseye.eu/)) offer new ways to read and access an in-depth analysis of extensive collections of European historical newspapers. This course is intended to bring such material and tools as a rich and diverse application framework for learning or teaching Digital Humanities (DH).
 

--- a/content/en/resources/external/digital-humanities-research-questions-and-methods/index.mdx
+++ b/content/en/resources/external/digital-humanities-research-questions-and-methods/index.mdx
@@ -40,7 +40,6 @@ remote:
   publication-date: 2019-10-04
   url: https://training.parthenos-project.eu/sample-page/digital-humanities-research-questions-and-methods/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-3176-759a-a9f7-d25d2a427499
 dariah-national-consortia:
   - lu
 ---

--- a/content/en/resources/external/digital-scholarly-editions-manuscripts-texts-and-tei-encoding/index.mdx
+++ b/content/en/resources/external/digital-scholarly-editions-manuscripts-texts-and-tei-encoding/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2017-07-12
   url: https://teach.dariah.eu/course/view.php?id=32
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-31ac-728f-9549-3f382f2e0541
 ---
 Do you want to create a digital scholarly edition? Then this course is for you! Here you will learn to master the technologies of XML, the Text Encoding Initiative (TEI), and XSLT to produce great digital editions. You will learn to create critical editions, facsimile editions and useful visualizations of your editions.
 

--- a/content/en/resources/external/digitality-and-music-editions-thinking-about-the-roles-of-editors/index.mdx
+++ b/content/en/resources/external/digitality-and-music-editions-thinking-about-the-roles-of-editors/index.mdx
@@ -33,7 +33,6 @@ content-type: video
 translations: []
 dariah-national-consortia:
   - at
-doi: https://hdl.handle.net/21.11159/019595c4-31e4-765c-8aea-5aafa679f421
 ---
 Digitality is as much a method as it is phenomenon of textuality and media – or: 'mediality'. In musical editions it opens new ways of accessing and presenting music and musical sources. Researchers who deal with these questions are permanently changing their roles as music philologists, editors and mediators. Following the diverse discussions about authorship in literature studies and, for some time, in musicology, this lecture aims to focus on editors and their various roles as actors of digitality.
 

--- a/content/en/resources/external/digitisation-methods-for-material-culture/index.mdx
+++ b/content/en/resources/external/digitisation-methods-for-material-culture/index.mdx
@@ -34,7 +34,6 @@ remote:
   publication-date: 2024-07-09
   url: https://culturedigitalskills.github.io/2024-3d-digitisation-methods/
   publisher: Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-321d-76ac-bebe-cd209ad7ddb3
 ---
 This resource is an introduction to Digitisation Methods for Material Culture. The resource explores basic topics with regards to the study of material culture, while also looking at types of media as means to communicate and share information about it, as well as digitisation methods to capture material culture data.
 

--- a/content/en/resources/external/digitisation-with-360-degrees-photography/index.mdx
+++ b/content/en/resources/external/digitisation-with-360-degrees-photography/index.mdx
@@ -35,7 +35,6 @@ remote:
   publication-date: 2024-07-09
   url: https://culturedigitalskills.github.io/2024-360-digitisation/
   publisher: Culture Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-3254-71b9-9dae-1a387e75decb
 ---
 This resource is an introduction to 360 degrees panorama photography. It explores different types of panoramic representations and examples of 360 degree panoramas in the cultural heritage domain. Practical advice and step by step guidance on how to capture data and process them is also included in order to produce and publish 360 degrees panorama images.
 

--- a/content/en/resources/external/digitising-dictionaries/index.mdx
+++ b/content/en/resources/external/digitising-dictionaries/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2016-07-21
   url: https://teach.dariah.eu/course/view.php?id=20
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-328c-76fc-bca3-2e4678766093
 dariah-national-consortia:
   - sr
 ---

--- a/content/en/resources/external/digitization-workflow-talk-with-esau-dozio/index.mdx
+++ b/content/en/resources/external/digitization-workflow-talk-with-esau-dozio/index.mdx
@@ -35,7 +35,6 @@ remote:
   publication-date: 2025-01-17
   url: https://doi.org/10.5281/zenodo.11224325
   publisher: zenodo
-doi: https://hdl.handle.net/21.11159/019595c4-32c6-71bb-b36c-56251382b7cd
 ---
 This podcast produced by virtualculture.ch features a conversation between Jane Haller, president of the Digitales Schaudepot, and Esaù Dozio, curator at the Antikenmuseum Basel.  In it they discuss the processes of curating a special exhibition; the perceived advantages and disadvantages between physical and digital exhibitions both in terms of management and curation, and the impact both might have on the public; and what mistakes, missteps and challenges were faced along the way.
 

--- a/content/en/resources/external/digitization-workflow-talk-with-joana-meier/index.mdx
+++ b/content/en/resources/external/digitization-workflow-talk-with-joana-meier/index.mdx
@@ -32,7 +32,6 @@ remote:
   publication-date: 2025-01-16
   url: https://doi.org/10.5281/zenodo.11224008
   publisher: zenodo
-doi: https://hdl.handle.net/21.11159/019595c4-32fb-71c9-9e1a-30ae7ec1877f
 ---
 What does "curating data stories" mean from a technical and academic perspective?  In this podcast, produced by virtualculture.ch, sociologist Jane Haller, president of the Digitales Schaudepot, is in conversation with Joana Meier a Master's student in Digital Humanities at the University of Basel, working in museum education and digitization.  Throughout their conversation, they discuss the processes of data visualisation, and how digitalization has opened up new research questions.
 

--- a/content/en/resources/external/digitization-workflow-talk-with-sorin-marti/index.mdx
+++ b/content/en/resources/external/digitization-workflow-talk-with-sorin-marti/index.mdx
@@ -36,7 +36,6 @@ remote:
   publication-date: 2025-01-17
   url: https://doi.org/10.5281/zenodo.11224449
   publisher: zenodo
-doi: https://hdl.handle.net/21.11159/019595c4-3331-740a-85e0-12f25ecc6379
 ---
 How do we display data as we want, but still store it as we should?  This podcast, produced by virtualculture.ch, offers the data steward's perspective on digitisation.  Sociologist Jane Haller is in conversation with data steward Sorin Marti (based at the Research Infrastructure Support Entity at the University of Basel) about what it means to make data available from the 'front end' while still maintaining the data integrity behind the scenes.
 

--- a/content/en/resources/external/displaying-a-georeferenced-map-in-knightlab-storymap-js/index.mdx
+++ b/content/en/resources/external/displaying-a-georeferenced-map-in-knightlab-storymap-js/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2022-05-16
   url: https://doi.org/10.46430/phen0098
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-3369-75e9-91ff-4dc32a8826a3
 ---
 Georeferencing is the process of assigning geographic coordinates to a scanned map or raster image.
 Many historians are now georeferencing historical maps to study how places have changed over time.

--- a/content/en/resources/external/dublin-in-the-archives-digital-collections-exploring-the-city-and-county/index.mdx
+++ b/content/en/resources/external/dublin-in-the-archives-digital-collections-exploring-the-city-and-county/index.mdx
@@ -33,7 +33,6 @@ remote:
   publication-date: 2021-09-17
   url: https://doi.org/10.7486/DRI.1z410h71k
   publisher: Digital Repository of Ireland
-doi: https://hdl.handle.net/21.11159/019595c4-33a0-77ff-839c-279da42296e9
 ---
 This recording is of 'Dublin in the Archives: Digital collections exploring the city and county' a webinar hosted by the Digital Repository of Ireland (DRI) for Culture Night in September 2021.
 

--- a/content/en/resources/external/e-humanities-and-e-heritage-research-infrastructures-beyond-tools/index.mdx
+++ b/content/en/resources/external/e-humanities-and-e-heritage-research-infrastructures-beyond-tools/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2018-02-22
   url: https://training.parthenos-project.eu/sample-page/ehumanities-eheritage-webinar-series/webinar-beyond-tools/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-33d4-751f-b2d9-883ad62ff0fd
 ---
 This is a record of a webinar providing a theoretical basis for a general understanding of the digital and infrastructural turn in the (Digital) Humanities and Cultural Heritage along with theoretical and critical reflections around the topic: Which opportunities and challenges do Cultural Heritage and Digital Humanities Research Infrastructures offer for research(ers)?
 

--- a/content/en/resources/external/editing-jane-austen/index.mdx
+++ b/content/en/resources/external/editing-jane-austen/index.mdx
@@ -25,7 +25,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-3407-7789-b725-cb0e6d06f0a3
 ---
 This video features Kathryn Sutherland (Professor of Bibliography and Textual Criticism at the University of Oxford) talking about Jane Austen's fiction manuscripts. This project brought together, in digital form, a manuscript collection originally scattered around the world, including transcripts, information about each manuscript, and a search facility.
 

--- a/content/en/resources/external/ehri-in-teitok/index.mdx
+++ b/content/en/resources/external/ehri-in-teitok/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2021-03-17
   url: https://blog.ehri-project.eu/2021/03/17/ehri-in-teitok/
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-343a-764b-bdf5-80e6f0aa7461
 dariah-national-consortia:
   - nl
 ---

--- a/content/en/resources/external/encode-course-digital-tools-for-the-research-and-study-of-ancient-writing-cultures/index.mdx
+++ b/content/en/resources/external/encode-course-digital-tools-for-the-research-and-study-of-ancient-writing-cultures/index.mdx
@@ -48,7 +48,6 @@ remote:
   publication-date: 2023-09-05
   url: https://teach.dariah.eu/course/view.php?name=ENCODE
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-3470-7735-9698-100bd9059df5
 dariah-national-consortia:
   - be
 ---

--- a/content/en/resources/external/engaging-communities-with-archives-video-as-a-tool-for-activism-advocacy-and-archival-work/index.mdx
+++ b/content/en/resources/external/engaging-communities-with-archives-video-as-a-tool-for-activism-advocacy-and-archival-work/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2021-09-07
   url: https://doi.org/10.7486/DRI.4168n731n
   publisher: Digital Repository of Ireland, Public Record Office of Northern Ireland
-doi: https://hdl.handle.net/21.11159/019595c4-34a5-7229-ac73-67dc83e60746
 ---
 This recording is of **'Engaging Communities with Archives: Video as a tool for activism, advocacy, and archival work'**, a collaborative event hosted by the Digital Repository of Ireland (DRI) and the Public Record Office of Northern Ireland (PRONI) on **7 Sept 2021**.
 

--- a/content/en/resources/external/entity-matching/index.mdx
+++ b/content/en/resources/external/entity-matching/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2019-08-15
   url: https://github.com/EHRI/ehri-data-analysis-tools/tree/master/entity-matching
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-34da-70a0-96a9-ca39cb667bf3
 ---
 EHRI (European Holocaust Research Infrastructure) supports the use of digital tools that can assist in the research of Holocaust and refugee related topics. It works to make these tools as accessible as possible so that researchers who have no experience with digital tools will consider trying new ways of using their data.
 

--- a/content/en/resources/external/evaluation-of-digital-heritage-experiences/index.mdx
+++ b/content/en/resources/external/evaluation-of-digital-heritage-experiences/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2023-11-28
   url: https://universityofbrighton.github.io/2023-exhibition-evaluation/
   publisher: Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-350d-74ef-b362-b7d9eff872fa
 ---
 Evaluation is a critical task, given that gathering and making sense of audience feedback enables museum professionals to reflect upon their work, while tracing the impact of organisations' provision and shaping digital policies and plans.
 

--- a/content/en/resources/external/exploratory-topic-modelling-in-python/index.mdx
+++ b/content/en/resources/external/exploratory-topic-modelling-in-python/index.mdx
@@ -30,7 +30,6 @@ remote:
   publication-date: 2022-06-21
   url: https://blog.ehri-project.eu/2022/07/19/exploratory-topic-modelling-in-python/
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-3540-76f6-904e-be32dc56c736
 ---
 Topic modelling is a machine-learning technique that finds patterns in language use within a corpus of documents, and clusters those documents accordingly.   The commonalities in ther patterns form "topics", providing a way to automatically categorise documents by their structural content. The specific type of topic modelling covered in this resource is called Latent Dirichlet Allocation - 'LDA'.
 

--- a/content/en/resources/external/extracting-csv-data-from-the-ehri-search-api/index.mdx
+++ b/content/en/resources/external/extracting-csv-data-from-the-ehri-search-api/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2019-08-15
   url: https://github.com/EHRI/ehri-data-analysis-tools/tree/master/ehri-search-api
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-3575-7632-a9cc-38e844cc9923
 ---
 This tutorial shows you how to use some popular command-line tools (available on MacOS, Linux, and Windows) to extract data from the EHRI Search API and convert it to CSV, where it can be imported into Excel or a relational database. The tools we will be using are as follows:
 

--- a/content/en/resources/external/facial-recognition-in-historical-photographs-with-artificial-intelligence-in-python/index.mdx
+++ b/content/en/resources/external/facial-recognition-in-historical-photographs-with-artificial-intelligence-in-python/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2024-06-25
   url: https://doi.org/10.46430/phen0119
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-35a8-77a3-9e80-0f9865c9b391
 ---
 This lesson is meant as an introductory exercise in applying computer vision machine learning to historical photos. You'll learn computer vision and machine learning principles for object recognition, and how to apply these principles using Python to recognize and classify smiling faces in historical photographs. This lesson will also serve as an introduction to some of the ethical issues posed by the use of AI in the study of photographs, particularly those implicating race and gender.
 

--- a/content/en/resources/external/fair-multidimensional-data/index.mdx
+++ b/content/en/resources/external/fair-multidimensional-data/index.mdx
@@ -36,7 +36,6 @@ remote:
   publication-date: 2023-11-23
   url: https://universityofbrighton.github.io/2023-fair-multidimensional-media/
   publisher: Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-35e3-7020-8230-280d7403b698
 ---
 This resource aims to support better understanding of multidimensional media available over the web which might serve various educational, research, as well as storytelling and audience engagement processes.  Learners will engage in methods for managing media in a way which promotes the FAIR principles, and be introduced to the concept of a Virtual Research Environment to support retrieval and curation of multidimensional data for storytelling via interoperable frameworks.
 

--- a/content/en/resources/external/finding-places-in-text-with-the-world-historical-gazetteer/index.mdx
+++ b/content/en/resources/external/finding-places-in-text-with-the-world-historical-gazetteer/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2022-02-11
   url: https://doi.org/10.46430/phen0096
   publisher: ProgHist Ltd.
-doi: https://hdl.handle.net/21.11159/019595c4-361b-71fc-b935-5409f4a20826
 ---
 Researchers often need to be able to search a corpus of texts for a defined list of terms. In many cases, historians are interested in certain places named in a text or texts. This lesson details how to programmatically search documents for a list of terms, including place names. To begin, we will produce a tab-separated value (TSV) file where each row gives the matched term and the term's location in the text. We also generate a visualisation that can be used to interpret the matches in context and to assess their usefulness for a given project. The goal of the lesson is to systematically search a text corpus for place names and then to use a service to locate and map historic place names.
 

--- a/content/en/resources/external/formal-ontologies-a-complete-novices-guide/index.mdx
+++ b/content/en/resources/external/formal-ontologies-a-complete-novices-guide/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2018-12-07
   url: http://training.parthenos-project.eu/sample-page/formal-ontologies-a-complete-novices-guide/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-364e-704e-bff0-ad089d03a0c7
 ---
 If you have worked with or managed data, the chances are you have probably at least heard of 'ontologies' or some other methods of formal knowledge representation. The concept of ontologies in a philosophical sense could be something that you are more or less comfortable with but they could be something that you find a bit daunting, especially if you don't know where to begin.
 

--- a/content/en/resources/external/from-the-archival-to-the-digital-turn-a-lesson-on-source-criticism/index.mdx
+++ b/content/en/resources/external/from-the-archival-to-the-digital-turn-a-lesson-on-source-criticism/index.mdx
@@ -36,7 +36,6 @@ remote:
   publication-date: 2018-10-18
   url: https://ranke2.uni.lu/u/archival-digital-turn/
   publisher: ranke2lu
-doi: https://hdl.handle.net/21.11159/019595c4-3681-749e-8816-44fdd5ea31b7
 dariah-national-consortia:
   - lu
 ---

--- a/content/en/resources/external/from-the-shelf-to-the-web-exploring-historical-newspapers-in-the-digital-age/index.mdx
+++ b/content/en/resources/external/from-the-shelf-to-the-web-exploring-historical-newspapers-in-the-digital-age/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2020-02-20
   url: https://ranke2.uni.lu/u/exploring-historical-newspapers/
   publisher: Ranke.2
-doi: https://hdl.handle.net/21.11159/019595c4-36b3-754d-bf19-2bd001f22e8d
 dariah-national-consortia:
   - lu
 ---

--- a/content/en/resources/external/game-play-design-in-the-arts-and-humanities/index.mdx
+++ b/content/en/resources/external/game-play-design-in-the-arts-and-humanities/index.mdx
@@ -25,7 +25,6 @@ remote:
   publication-date: 2020-06-16
   url: https://teach.dariah.eu/course/view.php?id=57
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-36e7-73bb-8539-a3f037e42ea8
 ---
 This course introduces you to the definition of games, core concepts and theories from game studies as well as the cultural importance of games and the critical potentials and possibilities for change that games hold.
 

--- a/content/en/resources/external/greek-latin-classics-and-the-need-for-a-global-philology/index.mdx
+++ b/content/en/resources/external/greek-latin-classics-and-the-need-for-a-global-philology/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2018-01-17
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-lecture-32
   publisher: Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)
-doi: https://hdl.handle.net/21.11159/019595c4-371d-7418-b5e4-7acef3c2db52
 dariah-national-consortia:
   - at
 ---

--- a/content/en/resources/external/how-to-capture-and-reference-a-webpage-in-your-research-using-zotero/index.mdx
+++ b/content/en/resources/external/how-to-capture-and-reference-a-webpage-in-your-research-using-zotero/index.mdx
@@ -23,7 +23,6 @@ remote:
   publication-date: 2019-08-15
   url: https://github.com/EHRI/ehri-data-analysis-tools/tree/master/zotero
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-3750-77ce-97cc-c91e774ff205
 ---
 The need to reference webpages in academic work is growing all the time, particularly in the digital humanities. There are many different reference management systems that exist to help researchers sort and find their sources, and the most accessible of these is Zotero. This short guide will show you how to use Zotero to capture webpages that can then be cited in your work.
 

--- a/content/en/resources/external/how-to-work-together-successfully-with-e-humanities-and-e-heritage-research-infrastructures/index.mdx
+++ b/content/en/resources/external/how-to-work-together-successfully-with-e-humanities-and-e-heritage-research-infrastructures/index.mdx
@@ -35,7 +35,6 @@ remote:
   publication-date: 2018-02-13
   url: https://training.parthenos-project.eu/sample-page/ehumanities-eheritage-webinar-series/webinar-work-with-research-infrastructures/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-3784-72c9-bdc7-a43a008b4dc9
 ---
 This is a record of a webinar dedicated to the phase of the research life cycle "Plan Research Project". It first introduces the participants to an understanding of the advantages and practicalities of research collaboration in and with Research infrastructures. It then dives into details of project planning, touches upon the basics of the FAIR principles, and focuses especially on the importance of using standards in Digital Humanities and Cultural Heritage research and how to identify relevant standards for the participants' own research. This webinar gives an introduction to the Standards Survival Kit that is developed within PARTHENOS. It also cross-links to other materials developed within PARTHENOS and by the PARTHENOS Cluster Partners.
 

--- a/content/en/resources/external/importing-tables-from-websites-into-spreadsheets/index.mdx
+++ b/content/en/resources/external/importing-tables-from-websites-into-spreadsheets/index.mdx
@@ -23,7 +23,6 @@ remote:
   publication-date: 2019-08-15
   url: https://github.com/EHRI/ehri-data-analysis-tools/tree/master/importing-web-tables
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-37ba-71d5-b64b-f0aba14442ab
 ---
 Sometimes in the course of humanities research it can be useful to take information, such as document lists from archives, from a website for future reference. If these items are in a table on a webpage, it is possible to capture these and import them into a spreadsheet for further analysis with the help of browser extensions.  This short resource will show the user how to download an extension to copy tables from websites (in this case, 'Table Capture' in the Google Chrome browser), and then import the table into a spreadsheet program.
 

--- a/content/en/resources/external/interrogating-a-national-narrative-with-gpt-2/index.mdx
+++ b/content/en/resources/external/interrogating-a-national-narrative-with-gpt-2/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2022-10-03
   url: https://doi.org/10.46430/phen0104
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-3800-724b-95cb-6d7dcf391971
 ---
 This lesson is intended to teach you how to apply Generative Pre-trained Transformer 2 (GPT-2), one of the largest existing open-source language models, to a large-scale text corpus in order to produce automatically-written responses to prompts based on the contents of the corpora, aiding in the task of locating the broader themes and trends that emerge from within your body of work. This method of analysis is useful for historical inquiry as it allows for a narrative crafted over years and thousands of texts to be aggregated and condensed, then analyzed through direct inquiry. In essence, it allows you to "talk" to your sources.
 

--- a/content/en/resources/external/introduction-to-collaborations-in-research-infrastructures/index.mdx
+++ b/content/en/resources/external/introduction-to-collaborations-in-research-infrastructures/index.mdx
@@ -23,7 +23,6 @@ remote:
   publication-date: 2017-02-17
   url: http://training.parthenos-project.eu/sample-page/introduction-to-collaboration-in-research-infrastructures/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-384e-71b7-95d4-6b34cedd2338
 ---
 Is humanities research collaborative? Some would say that with our traditions of independent research and single authorship, it is not. This is not really true for any humanist, however, as collaboration does occur within classrooms, on-line communities, and within disciplinary networks. For the digital humanities, this is even more the case, as the hybridity of our methods require us to work together. Very few digital humanists can master entirely on their own the domain, information and software challenges their approach presents, and so we tend to work together.
 

--- a/content/en/resources/external/introduction-to-design-thinking-and-maker-culture/index.mdx
+++ b/content/en/resources/external/introduction-to-design-thinking-and-maker-culture/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2020-04-22
   url: https://teach.dariah.eu/course/view.php?id=68&section=0
   publisher: dariahTEACH
-doi: https://hdl.handle.net/21.11159/019595c4-38a7-73ff-b9e1-4b9ff8903b3e
 dariah-national-consortia:
   - nl
 ---

--- a/content/en/resources/external/introduction-to-digital-humanities/index.mdx
+++ b/content/en/resources/external/introduction-to-digital-humanities/index.mdx
@@ -25,7 +25,6 @@ remote:
   publication-date: 2016-12-13
   url: https://teach.dariah.eu/course/view.php?id=26
   publisher: dariahTEACH
-doi: https://hdl.handle.net/21.11159/019595c4-38e1-77eb-a0d7-8347712a1307
 dariah-national-consortia:
   - nl
 ---

--- a/content/en/resources/external/introduction-to-knowledge-organization-systems/index.mdx
+++ b/content/en/resources/external/introduction-to-knowledge-organization-systems/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2023-05-23
   url: https://teach.dariah.eu/course/view.php?id=79
   publisher: dariahTeach
-doi: https://hdl.handle.net/21.11159/019595c4-3916-70c0-adec-0beae5850874
 dariah-national-consortia:
   - se
 ---

--- a/content/en/resources/external/introduction-to-map-warper/index.mdx
+++ b/content/en/resources/external/introduction-to-map-warper/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2022-10-24
   url: https://doi.org/10.46430/phen0106
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-394e-72f7-aacb-8c706185d0f4
 ---
 Georeferencing is the process of assigning geographic coordinates to a scanned map or raster image. Many historians georeference maps to study how places have changed over time. In this lesson, we will take you through the steps to align geographic coordinates to a scanned historical map and show you how to export your georeferenced map.
 

--- a/content/en/resources/external/introduction-to-programming-for-nlp-with-python/index.mdx
+++ b/content/en/resources/external/introduction-to-programming-for-nlp-with-python/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2022-05-04
   url: https://mitt.uib.no/courses/38115/
   publisher: University of Bergen (Norway)
-doi: https://hdl.handle.net/21.11159/019595c4-397a-746b-a8f2-59d9faf6a351
 ---
 The core of the course consists of a series of Jupyter notebooks that combine examples of Python code with explanatory text. The notebooks provide demonstrations of simple language processing and the aggregation, analysis and visualisation of qualitative and quantitative data, including data from real language research, from CLARINO, and from other sources on the web. They also suggest exercises which should solvable on the basis of the given examples and explanations. The course also has an introduction into the challenges of multilingual processing.
 

--- a/content/en/resources/external/introduction-to-research-infrastructures/index.mdx
+++ b/content/en/resources/external/introduction-to-research-infrastructures/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2018-04-11
   url: http://training.parthenos-project.eu/sample-page/intro-to-ri/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-39a6-77da-b1b9-a9686694770c
 dariah-national-consortia:
   - nl
 ---

--- a/content/en/resources/external/introduction-to-the-e-spectator-digital-tool-for-analysis-of-performing-arts/index.mdx
+++ b/content/en/resources/external/introduction-to-the-e-spectator-digital-tool-for-analysis-of-performing-arts/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2023-05-22
   url: https://teach.dariah.eu/course/view.php?id=76&section=0
   publisher: dariahTeach
-doi: https://hdl.handle.net/21.11159/019595c4-39d4-753f-bb41-2168c4f8b188
 dariah-national-consortia:
   - fr
 ---

--- a/content/en/resources/external/knowledge-design/index.mdx
+++ b/content/en/resources/external/knowledge-design/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2016-06-23
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-lecture-21
   publisher: Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)
-doi: https://hdl.handle.net/21.11159/019595c4-39ff-76fd-990d-21685bf50fa5
 dariah-national-consortia:
   - at
 ---

--- a/content/en/resources/external/looking-for-revolution-in-the-data-pool-some-observations-from-cesta-at-stanford/index.mdx
+++ b/content/en/resources/external/looking-for-revolution-in-the-data-pool-some-observations-from-cesta-at-stanford/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2016-10-19
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-lecture-22
   publisher: " Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)"
-doi: https://hdl.handle.net/21.11159/019595c4-3a2b-724e-939d-28931f6321ec
 dariah-national-consortia:
   - at
 ---

--- a/content/en/resources/external/make-it-happen-carrying-out-research-and-analysing-data/index.mdx
+++ b/content/en/resources/external/make-it-happen-carrying-out-research-and-analysing-data/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2018-04-05
   url: https://training.parthenos-project.eu/sample-page/ehumanities-eheritage-webinar-series/webinar-boost-your-ehumanities-and-eheritage-research-with-research-infrastructures/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-3a62-7381-b3e6-6aa7b81512c2
 ---
 This is a record of a webinar dedicated to the phases of the research lifecycle "Carry out Research" & "Analyse Data" in the context of a research infrastructure. Carrying out research and analysis in the context of a research infrastructure requires a change in approach to research, where the harmonization of data and the ability to access and deploy interoperable services is crucial. This webinar gives an overview of the necessary elements required to set up a sustainable research infrastructure with regards to the management of data and services.
 

--- a/content/en/resources/external/making-an-interactive-web-application-with-r-and-shiny/index.mdx
+++ b/content/en/resources/external/making-an-interactive-web-application-with-r-and-shiny/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2022-10-19
   url: https://doi.org/10.46430/phen0105
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-3aa3-768f-b310-111a1fbcac40
 ---
 This lesson demonstrates how to build a basic interactive web application using Shiny. Shiny is a library (a set of additional functions) for the programming language R. Its purpose is to facilitate the development of web applications, which allow a user to interact with R code using User Interface (UI) elements in a web browser, such as sliders, drop-down menus, and so forth. In the lesson, you will design and implement a simple application, consisting of a slider which allows a user to select a date range, which will then trigger some code in R, and display a set of corresponding points on an interactive map.
 

--- a/content/en/resources/external/manage-improve-and-open-up-your-research-data/index.mdx
+++ b/content/en/resources/external/manage-improve-and-open-up-your-research-data/index.mdx
@@ -39,7 +39,6 @@ remote:
   publication-date: 2018-01-26
   url: https://training.parthenos-project.eu/sample-page/manage-improve-and-open-up-your-research-and-data/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-3ad6-7719-b78b-235a4e433a00
 ---
 This module looks at emerging trends and best practice in data management, quality assessment and IPR issues. It looks at policies regarding data management and their implementation, particularly in the framework of a Research Infrastructure.
 

--- a/content/en/resources/external/management-challenges-in-research-infrastructures/index.mdx
+++ b/content/en/resources/external/management-challenges-in-research-infrastructures/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2018-04-11
   url: http://training.parthenos-project.eu/sample-page/management-challenges/
   publisher: PARTHENOS
-doi: https://hdl.handle.net/21.11159/019595c4-3b02-74fc-8cd1-81e180f41ca4
 ---
 This module looks at some of the key management issues that arise within research infrastructures with a clarity and urgency they don't often have below the infrastructural scale. It also looks at key trends and developments in these areas, and how exemplar projects are applying them. In particular, this module covers: User Engagement, Communications and Audiences, Sustainability, and the Macro-level issues, including managing the political environment.
 

--- a/content/en/resources/external/mixed-reality-and-social-engagement/index.mdx
+++ b/content/en/resources/external/mixed-reality-and-social-engagement/index.mdx
@@ -28,7 +28,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-3b2f-7254-803b-ad8739c004d8
 ---
 This video features Tamar Gordon, Professor of Anthropology at Rensselaer Polytechnic Institute, USA. In this video she discusses Mixed Reality and Social Engagement. Tamar talks about Augmented Reality as a tool that can make history come alive, while helping us to interpret cultural-historical environments and reflect upon our own experience and subject position within our own society.
 

--- a/content/en/resources/external/more-watching-less-searching-repurposing-fortunoff-archive-metadata-for-visual-searching/index.mdx
+++ b/content/en/resources/external/more-watching-less-searching-repurposing-fortunoff-archive-metadata-for-visual-searching/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2020-09-01
   url: https://blog.ehri-project.eu/2020/09/01/fortunoff-archive-metadata/
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-3b62-773c-9348-8d504131e619
 ---
 The [Fortunoff Video Archive For Holocaust Testimonies](https://fortunoff.library.yale.edu/) and the Yale Digital Humanities Lab (DHLab) began building a [*Visual Search* tool](https://yale-fortunoff.github.io/metadash/) in 2019 in order to provide a simple overview of the Fortunoff Archive's collection and enable quick filtering and discovery of relevant testimonies. Before this, researchers who were new to Fortunoff's collection would often find searching for testimonies in Yale's public access catalogue an opaque process.
 

--- a/content/en/resources/external/multimodal-literacies/index.mdx
+++ b/content/en/resources/external/multimodal-literacies/index.mdx
@@ -25,7 +25,6 @@ remote:
   publication-date: 2016-11-27
   url: https://teach.dariah.eu/course/view.php?id=24&section=0
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-3b91-7402-b195-974dceb42338
 ---
 This course invites you to discover the world of digital multimodal literacies through examples, experiments, readings and tools. Unit I consists of an introduction to multimodal literacies. Unit II allows you to discover, read and experiment with different examples of multimodal literacies. Finally, Unit III will allow you to build your own multimodal editing tool, an eTalk, on a virtual machine. Enjoy your travels in multimodal literacies!
 

--- a/content/en/resources/external/my-digital-humanities-a-feminist-reading/index.mdx
+++ b/content/en/resources/external/my-digital-humanities-a-feminist-reading/index.mdx
@@ -28,7 +28,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-3bbf-752a-9e3c-fe0dafef36aa
 ---
 This video features Laura Mandell, Professor of English and Director of the Initiative for Digital Humanities, Media, and Culture a Texas A\&M University. Laura defines feminism from a Digital Humanities perspective arguing for a need to adjust practices so that they are not replicating the sexist infrastructure of the traditional academy and business world.
 

--- a/content/en/resources/external/my-digital-humanities-visualising-text/index.mdx
+++ b/content/en/resources/external/my-digital-humanities-visualising-text/index.mdx
@@ -30,7 +30,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-3bf0-75ab-a6ea-c153c6673404
 ---
 This video features Geoffrey Rockwell, Professor of Philosophy and Humanities Computing at the University of Alberta, Canada and Stéfan Sinclair, Associate Professor of Digital Humanities at McGill University. Their discussion involves text visualisation within Digital Humanities, thus emphasising, that visualisation is not the end product, but an intellectual process of thinking and interpreting text. Interactive visualisations, uses of visualisation for narrative, physical computing, video games, and Pokemon Go are also discussed.
 

--- a/content/en/resources/external/netnography/index.mdx
+++ b/content/en/resources/external/netnography/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2023-05-22
   url: https://teach.dariah.eu/course/view.php?id=73
   publisher: dariahTeach
-doi: https://hdl.handle.net/21.11159/019595c4-3c1b-7703-934c-f0bf46960cc2
 dariah-national-consortia:
   - se
 ---

--- a/content/en/resources/external/ocr-with-google-vision-api-and-tesseract/index.mdx
+++ b/content/en/resources/external/ocr-with-google-vision-api-and-tesseract/index.mdx
@@ -25,7 +25,6 @@ remote:
   publication-date: 2023-03-31
   url: https://doi.org/10.46430/phen0109
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-3c46-726c-a2ef-c9322ae9fc21
 dariah-national-consortia:
   - be
 ---

--- a/content/en/resources/external/open-education-and-moocs/index.mdx
+++ b/content/en/resources/external/open-education-and-moocs/index.mdx
@@ -26,7 +26,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-3c78-739a-a928-776880f8b34c
 ---
 This video features Prof. Graeme Earl (Director of Enterprise and Impact (Humanities), University of Southampton) talking about the benefits and challenges of Open Education and Massive Open Online Courses. This video was recorded during the Virtual Heritage Network Conference (December 2016, Cork, Ireland) while he was Professor of Digital Humanities at the University of Southampton. Prof. Earl subsequently moved to King's College London where he is a Professor of Digital Humanities.
 

--- a/content/en/resources/external/performing-promoting-and-preserving-ireland-s-intangible-cultural-heritage/index.mdx
+++ b/content/en/resources/external/performing-promoting-and-preserving-ireland-s-intangible-cultural-heritage/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2021-08-19
   url: https://doi.org/10.7486/DRI.9w03fs89x
   publisher: Digital Repository of Ireland
-doi: https://hdl.handle.net/21.11159/019595c4-3ca2-7686-a899-26130625ddb7
 ---
 This recording is of 'Performing, Promoting and Preserving Ireland's Intangible Cultural Heritage'. This was a live online event co-organised by the Department of Tourism, Culture, Arts, Gaeltacht, Sport and Media and the Digital Repository of Ireland on 19 August 2021 at 19.00
 

--- a/content/en/resources/external/photogrammetry-3d-digitisation/index.mdx
+++ b/content/en/resources/external/photogrammetry-3d-digitisation/index.mdx
@@ -33,7 +33,6 @@ remote:
   publication-date: 2024-07-09
   url: https://culturedigitalskills.github.io/2024-digitisation-3d-photogrammetry/
   publisher: Digital Skills in Visual and Material Culture, University of Brighton
-doi: https://hdl.handle.net/21.11159/019595c4-3ccd-717e-911a-1c2bacc75038
 ---
 This resource is an introduction to the photogrammetry technique to capture visual data about cultural heritage assets and produce associated 3D models. Photogrammetry is a technique also known as Structure from Motion (SfM). Both terms are used to refer to the computing process of estimating the 3D structure of a scene from a set of 2D raster images. A photogrammetry software receives as an input a set of raster images of an object or environment and outputs a 3D model.
 

--- a/content/en/resources/external/photogrammetry-tutorial/index.mdx
+++ b/content/en/resources/external/photogrammetry-tutorial/index.mdx
@@ -24,7 +24,6 @@ remote:
   publication-date: 2024-02-03
   url: https://play.lnu.se/media/t/0_ptrvp9y0
   publisher: LNU Play
-doi: https://hdl.handle.net/21.11159/019595c4-3d00-702e-a65f-b62cfeacab23
 dariah-national-consortia:
   - se
 ---

--- a/content/en/resources/external/practicing-design-thinking-and-making/index.mdx
+++ b/content/en/resources/external/practicing-design-thinking-and-making/index.mdx
@@ -24,7 +24,6 @@ remote:
   publication-date: 2020-07-15
   url: https://teach.dariah.eu/course/view.php?id=60
   publisher: dariahTeach
-doi: https://hdl.handle.net/21.11159/019595c4-3d33-754c-b57f-1b4e7b13cb06
 ---
 Design thinking is much less about knowing and much more about doing. Donald Schön, in his groundbreaking work on design (1984, 1992), demonstrated that knowing is in the activity of designing, and that the two cannot be separated. The focus in this course is on the practical aspects of design thinking, offering the tools and methods for students and researchers to apply the principles of design thinking when facing problems of their own. Note that the course <Link link={{"discriminant":"resources-external","value":{"id":"introduction-to-design-thinking-and-maker-culture"}}}>Introduction to Design Thinking and Maker Culture</Link> offers extensive information on design thinking and makers culture as well. It offers most of all information on the 'what' and 'why'. This course focuses above all on the 'how'.
 

--- a/content/en/resources/external/quod-a-tool-for-querying-and-organising-digitised-historical-documents/index.mdx
+++ b/content/en/resources/external/quod-a-tool-for-querying-and-organising-digitised-historical-documents/index.mdx
@@ -30,7 +30,6 @@ remote:
   publication-date: 2018-03-29
   url: https://blog.ehri-project.eu/2018/03/29/quod/
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-3d65-7030-8069-ff407aa3f0b8
 dariah-national-consortia:
   - nl
 ---

--- a/content/en/resources/external/regression-analysis-with-scikit-learn-part-1-linear/index.mdx
+++ b/content/en/resources/external/regression-analysis-with-scikit-learn-part-1-linear/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2022-07-13
   url: https://doi.org/10.46430/phen0099
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-3d97-713d-b8f1-6bc0f64aeb5a
 ---
 This lesson is the first of two that focus on an indispensable set of data analysis methods, linear and logistic regression. Linear regression represents how one (or more) quantitative measures relate to, or predict, some other quantitative measure. A computational historian, for example, might use linear regression analysis to do the following:
 

--- a/content/en/resources/external/regression-analysis-with-scikit-learn-part-2-logistic/index.mdx
+++ b/content/en/resources/external/regression-analysis-with-scikit-learn-part-2-logistic/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2022-07-13
   url: https://doi.org/10.46430/phen0100
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-3dc8-74dc-aa9f-717219290943
 ---
 This lesson is the second of two that focus on an indispensable set of data analysis methods: logistic and linear regression. Linear regression represents how one (or more) quantitative measures relate to, or predict, some other quantitative measure. Logistic regression uses a similar approach to represent how one (or more) quantitative measures relate to, or predict, a category. Depending on one's home discipline, one might use logistic regression to do the following:
 

--- a/content/en/resources/external/remaking-material-culture-in-3d/index.mdx
+++ b/content/en/resources/external/remaking-material-culture-in-3d/index.mdx
@@ -25,7 +25,6 @@ remote:
   publication-date: 2020-06-08
   url: https://teach.dariah.eu/course/view.php?id=55
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-3e01-72ba-810d-824e17cb95da
 dariah-national-consortia:
   - nl
 ---

--- a/content/en/resources/external/retrieving-text-from-spoken-data/index.mdx
+++ b/content/en/resources/external/retrieving-text-from-spoken-data/index.mdx
@@ -31,7 +31,6 @@ content-type: video
 translations: []
 dariah-national-consortia:
   - nl
-doi: https://hdl.handle.net/21.11159/019595c4-3e34-7366-ae18-4b933594898e
 ---
 This video features speech technologist Henk van den Heuvel, linguist Silvia Calamai and data curator Louise Corti explaining how speech technology has reached the stage of being able to automatically recognise and retrieve speech in huge amounts of audio visual data.
 

--- a/content/en/resources/external/scalable-reading-of-structured-data/index.mdx
+++ b/content/en/resources/external/scalable-reading-of-structured-data/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2022-10-04
   url: https://doi.org/10.46430/phen0103
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-3e67-736f-943c-9d928bd7794c
 ---
 In this lesson, we introduce a workflow for scalable reading of structured data, combining close interpretation of individual data points and statistical analysis of the entire dataset. The lesson is structured in two parallel tracks:
 

--- a/content/en/resources/external/sentiment-analysis-with-syuzhet-using-r/index.mdx
+++ b/content/en/resources/external/sentiment-analysis-with-syuzhet-using-r/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2023-03-23
   url: https://doi.org/10.46430/phen0110
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-3e9c-7595-b018-742c88715f2e
 ---
 This lesson introduces you to the syuzhet sentiment analysis algorithm, written by Matthew Jockers using the R programming language, and applies it to a single narrative text to demonstrate its research potential. The term 'syuzhet' is Russian (сюже́т) and translates roughly as 'plot', or the order in which events in the narrative are presented to the reader, which may be different than the actual time sequence of events (the 'fabula'). The syuzhet package similarly considers sentiment analysis in a time-series-friendly manner, allowing you to explore the developing sentiment in a text across the pages.
 

--- a/content/en/resources/external/shaping-the-unseen-behind-the-scenes-of-data-visualization/index.mdx
+++ b/content/en/resources/external/shaping-the-unseen-behind-the-scenes-of-data-visualization/index.mdx
@@ -29,7 +29,6 @@ remote:
   publication-date: 2018-08-15
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-lecture-42
   publisher: Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)
-doi: https://hdl.handle.net/21.11159/019595c4-3ecf-7709-8f94-0554cc836240
 dariah-national-consortia:
   - nl
   - at

--- a/content/en/resources/external/sound-studies/index.mdx
+++ b/content/en/resources/external/sound-studies/index.mdx
@@ -23,7 +23,6 @@ remote:
   publication-date: 2016-10-25
   url: https://teach.dariah.eu/course/view.php?id=27
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-3f02-778a-ba8d-d8243f3b70c7
 ---
 The course introduces Sound Studies as a discipline that explores the multiple end dynamic meanings of sounds. Traditionally sound is seen as a medium for signification: the content of a radio program is the spoken word, and the content of music is musical form or structure. Sound Studies go beyond the paradigm of medium/content to reflect how sonic experiences are codified and interpreted at different cultural, discursive and historical moments. How do voice qualities and timbre produce meanings in different contexts? How can a sonic environment or a soundscape be experienced as meaningful respectively noisy?
 

--- a/content/en/resources/external/spatial-humanities-social-justice/index.mdx
+++ b/content/en/resources/external/spatial-humanities-social-justice/index.mdx
@@ -25,7 +25,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-3f34-7043-abfe-0adfed3f3b55
 ---
 This video features Angel D. Nieves, Professor of Africana Studies and Digital Humanities at Hamilton College, US. In this video, Angel talks about black spatial humanities, a field that tries to find out more about the history of African-descended people globally and the ways which digital humanists can begin to look at forms of institutional racism that have shaped African diaspora's experiences. He gives examples of his 3D visualisation work that looks at the ways in which the Apartheid government imposed restrictions to African-descended people and how such lost histories can be effectively communicated to a wider audience.
 

--- a/content/en/resources/external/spatial-image-analytics/index.mdx
+++ b/content/en/resources/external/spatial-image-analytics/index.mdx
@@ -26,7 +26,6 @@ remote:
   publication-date: 2017-12-23
   url: https://teach.dariah.eu/course/view.php?id=59
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-3f66-75fa-9400-91646a312d2a
 ---
 This workshop introduces participants to the background, and certain technologies and methods used for the spatial analysis of image datasets. The introduction provides a broad overview of the value of exploring the spatial properties of images while the rest of the workshop focuses on the methods of geotagging and spatial analysis through concrete examples and hands-on exercises.
 

--- a/content/en/resources/external/spatial-queries-and-the-first-deportations-from-slovakia/index.mdx
+++ b/content/en/resources/external/spatial-queries-and-the-first-deportations-from-slovakia/index.mdx
@@ -33,7 +33,6 @@ remote:
   publication-date: 2019-12-12
   url: https://blog.ehri-project.eu/2019/12/12/spatial-queries-first-deportations-slovakia/
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-3f9c-7202-a107-f6b5a342bf3a
 ---
 As part of his research (see EC-funded project Unlikely Refuge ([https://www.unlikely-refuge.eu](https://www.unlikely-refuge.eu/)), Michal Frankl examined the deportations of Jews from Slovakia in November 1938, many of whom were subsequently trapped along the demarcation line between the Czecho-Slovak and Hungarian post. The little known and extremely chaotic deportations were ordered by the Slovak President Jozef Tiso who blamed Jewish influence for the [First Vienna Award](https://en.wikipedia.org/wiki/First_Vienna_Award), an international arbitration which forced (Czecho-)Slovakia to cede southern Slovakia to Hungary.[](https://blog.ehri-project.eu/2019/12/12/spatial-queries-first-deportations-slovakia/#en-3886-1)
 

--- a/content/en/resources/external/storytelling-for-digital-narratives-and-blended-spaces/index.mdx
+++ b/content/en/resources/external/storytelling-for-digital-narratives-and-blended-spaces/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2020-06-10
   url: https://teach.dariah.eu/course/view.php?id=61&section=0
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-3fcf-71be-8fb4-461f4093303f
 ---
 This interdisciplinary course addresses how principles of textual, visual, oral, and place-based storytelling challenge and enhance the conceptualisation, construction and experience of digitally-created worlds connecting to real-world places, locations, and landscapes. Applying principles of storytelling to digital worlds across multiple situations, platforms, and environments (built and natural) will help define and innovate the shape of these worlds. Focused on the underlying belief that technology and narrative create a feedback loop, with one mediating the other, this unit will be based on iterations of ideation, conceptualisation, and prototyping to integrate critical insights that will push on the boundaries of established beliefs and the regulated time-space we live by, in the connectedness of datafied space and localised place.
 

--- a/content/en/resources/external/text-analysis-linguistics-meets-data-science/index.mdx
+++ b/content/en/resources/external/text-analysis-linguistics-meets-data-science/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2023-05-22
   url: https://teach.dariah.eu/mod/lesson/view.php?id=1686
   publisher: dariahTeach
-doi: https://hdl.handle.net/21.11159/019595c4-3ffb-739e-8c5c-f892730e84c9
 dariah-national-consortia:
   - se
 ---

--- a/content/en/resources/external/text-encoding-and-the-text-encoding-initiative/index.mdx
+++ b/content/en/resources/external/text-encoding-and-the-text-encoding-initiative/index.mdx
@@ -24,7 +24,6 @@ remote:
   publication-date: 2016-07-22
   url: https://teach.dariah.eu/course/view.php?id=23
   publisher: "#dariahTeach"
-doi: https://hdl.handle.net/21.11159/019595c4-4026-7119-bb9d-cf7f06149778
 ---
 This course is an introduction to the theories, practices, and methods that are used in the humanities for the encoding of texts for research, for preservation, and for online distribution. It focuses on a particular method, that of text encoding, using eXtensible Markup Language (XML), and a specialised schema common to humanities research, The Text Encoding Language (TEI).
 

--- a/content/en/resources/external/text-mining-youtube-comment-data-with-wordfish-in-r/index.mdx
+++ b/content/en/resources/external/text-mining-youtube-comment-data-with-wordfish-in-r/index.mdx
@@ -28,7 +28,6 @@ remote:
   publication-date: 2024-08-07
   url: https://doi.org/10.46430/phen0120
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-4053-764e-9b7c-de72ef884758
 ---
 This lesson will introduce readers to a method for conducting research on internet discourse by performing data analysis on comments posted under YouTube videos by viewers.
 

--- a/content/en/resources/external/text-versions-and-the-editorial-impulse/index.mdx
+++ b/content/en/resources/external/text-versions-and-the-editorial-impulse/index.mdx
@@ -26,7 +26,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-4083-7427-8854-45fc475c08f7
 ---
 This video features Paul Eggert, Martin J. Svaglic Endowed Chair in Textual Studies, Department of English, Loyola University Chicago, talking about textual studies and the study of versions as a methodology to ask questions revealing the lifespan of a text.
 

--- a/content/en/resources/external/textual-scholarship/index.mdx
+++ b/content/en/resources/external/textual-scholarship/index.mdx
@@ -31,7 +31,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-40b3-73b1-89ab-52ecfbe062b4
 ---
 This video features Dr. James Cummings, University of Oxford, Dr. Anne Baillot, Centre Marc Bloch, Dr. Marjorie Burghart, Centre National de la Recherche Scientifique CNRS, Prof Kenneth M. Price, University of Nebraska, and Prof Elena Pierazzo, Université Grenoble Alpes, interpreting what is textual scholarship and textual criticism.
 

--- a/content/en/resources/external/the-cls-infra-survey-of-methods-in-computational-literary-studies/index.mdx
+++ b/content/en/resources/external/the-cls-infra-survey-of-methods-in-computational-literary-studies/index.mdx
@@ -40,7 +40,6 @@ remote:
   publisher: CLS Infra
 content-type: website
 translations: []
-doi: https://hdl.handle.net/21.11159/019595c4-40de-76be-a528-4bec7ac33349
 dariah-national-consortia:
   - de
 ---

--- a/content/en/resources/external/the-learning-curve-in-sharing-data-with-the-ehri-project-the-example-of-a-memorial-site-kazerne-dossin-mechelen/index.mdx
+++ b/content/en/resources/external/the-learning-curve-in-sharing-data-with-the-ehri-project-the-example-of-a-memorial-site-kazerne-dossin-mechelen/index.mdx
@@ -36,7 +36,6 @@ remote:
   publication-date: 2018-06-19
   url: https://blog.ehri-project.eu/2018/06/19/kazerne-dossin-mechelen/
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-410b-764f-b758-e4e9cdf7060f
 ---
 [Kazerne Dossin – Memorial, Museum and Documentation Centre on Holocaust and Human Rights](https://www.kazernedossin.eu/EN/) opened its doors on 1st December 2012. The institute inherited its archival collections from its predecessor, the Jewish Museum of Deportation and Resistance (JMDR). The JMDR had been inaugurated in 1995 at the former SS-Sammellager Mecheln, better known as the Dossin barracks, in Belgium. Between the summer of 1942 and 1944 over 25,500 Jews, Roma and Sinti were deported from here to concentration camps in the East, mostly to Auschwitz-Birkenau.
 

--- a/content/en/resources/external/the-tei-guidelines-born-to-be-open/index.mdx
+++ b/content/en/resources/external/the-tei-guidelines-born-to-be-open/index.mdx
@@ -32,7 +32,6 @@ translations: []
 dariah-national-consortia:
   - fr
   - at
-doi: https://hdl.handle.net/21.11159/019595c4-4137-7132-a4a1-318c735350e4
 ---
 Open science has never been so high on the research agendas, and this is true in all fields, ranging from so-called hard sciences to the humanities. In this respect, those who have been dealing with the *TEI Guidelines* for years, whether as users or designers of the standard, have experienced an environment which has always been open by construction and fostering openness for projects based upon its principles.
 

--- a/content/en/resources/external/the-transformation-of-the-scholarly-edition-from-print-to-screen/index.mdx
+++ b/content/en/resources/external/the-transformation-of-the-scholarly-edition-from-print-to-screen/index.mdx
@@ -27,7 +27,6 @@ remote:
 content-type: video
 translations: []
 dariah-national-consortia: []
-doi: https://hdl.handle.net/21.11159/019595c4-416b-72dc-808c-4781abb1fed0
 ---
 This video features Paul Eggert, Loyola University Chicago, Kenneth M. Price, University of Nebraska, and Anne Baillot, Centre Marc Bloch, Berlin, talking about textual scholarship from analogue to digital.
 

--- a/content/en/resources/external/things-that-poems-taught-me-about-visualization/index.mdx
+++ b/content/en/resources/external/things-that-poems-taught-me-about-visualization/index.mdx
@@ -31,7 +31,6 @@ content-type: training-module
 translations: []
 dariah-national-consortia:
   - at
-doi: https://hdl.handle.net/21.11159/019595c4-419e-75b7-bcea-06d614bb5575
 ---
 For a computer scientist, collaborating with humanists can be a challenging, interesting, and productive experience. It can also seed ideas and insights with long-term implications for visualization research. In this talk, visualization designer Miriah Meyer reflects on a collaboration with poetry scholars that impacted her own research thinking in deep and disruptive ways. She describes learning that came out of this digital humanities project through the lens of several recent studies, each with core ideas that trace back to work with poetry scholars.
 

--- a/content/en/resources/external/train-the-trainer-research-data-management-bootcamp/index.mdx
+++ b/content/en/resources/external/train-the-trainer-research-data-management-bootcamp/index.mdx
@@ -42,7 +42,6 @@ remote:
   publication-date: 2021-02-08
   url: https://www.sshopencloud.eu/events/train-trainer-rdm-bootcamp
   publisher: SSHOC / DARIAH-EU Research Data Management Working Group
-doi: https://hdl.handle.net/21.11159/019595c4-41cf-70a7-b61a-ce2d047ec455
 ---
 This resource compiles the presentations and event report from the SSHOC / DARIAH Research Data Management Working Group "Train-the-Trainer Research Data Management Bootcamp", held across 2 half-days in February 2021.
 

--- a/content/en/resources/external/transcribing-handwritten-text-with-python-and-microsoft-azure-computer-vision/index.mdx
+++ b/content/en/resources/external/transcribing-handwritten-text-with-python-and-microsoft-azure-computer-vision/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2023-12-06
   url: https://doi.org/10.46430/phen0114
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-4206-751c-bfa4-25826d482db9
 ---
 Handwritten documents are appealing artifacts and a mainstay of research for many historians. Sources such as diaries, letters, logbooks and reports connect historians to writers not only through the writer's words, but also through their individual writing style. However, research involving large amounts of these documents represents a significant challenge: transcription of documents into digital form makes them more searchable, but hand transcription is very time-consuming. While historians have been able to digitize physical typewritten documents using optical character recognition (OCR), handwriting, with its individual styles, has until recently resisted recognition by computers.
 

--- a/content/en/resources/external/transformation-how-the-digital-creates-new-realities/index.mdx
+++ b/content/en/resources/external/transformation-how-the-digital-creates-new-realities/index.mdx
@@ -34,7 +34,6 @@ remote:
   publication-date: 2018-10-18
   url: https://ranke2.uni.lu/u/transformation/
   publisher: Ranke.2
-doi: https://hdl.handle.net/21.11159/019595c4-4238-75fb-8887-b535b611fd52
 dariah-national-consortia:
   - lux
 ---

--- a/content/en/resources/external/understanding-and-creating-word-embeddings/index.mdx
+++ b/content/en/resources/external/understanding-and-creating-word-embeddings/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2024-01-31
   url: https://doi.org/10.46430/phen0116
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-426c-70a4-a7b3-d3629c1d6d90
 ---
 Word embeddings allow you to analyze the usage of different terms in a corpus of texts by capturing information about their contextual usage. This lesson is designed to get you started with word embedding models. Through a primarily theoretical lens, this lesson will teach you how to prepare a corpus and train a word embedding model. You will explore how word vectors work, how to interpret them, and how to answer humanities research questions using them.
 

--- a/content/en/resources/external/using-digital-archives-for-geographical-and-archaeological-research/index.mdx
+++ b/content/en/resources/external/using-digital-archives-for-geographical-and-archaeological-research/index.mdx
@@ -32,7 +32,6 @@ remote:
   publication-date: 2021-03-23
   url: https://doi.org/10.7486/DRI.w663hs16k
   publisher: Digital Repository of Ireland
-doi: https://hdl.handle.net/21.11159/019595c4-429e-752b-8898-bc15a34c3a12
 ---
 This video is of "Using Digital Archives for Geographical and Archaeological Research", the **second** webinar in a three-part public lecture series on using digital archives for academic research hosted by the Digital Repository of Ireland (DRI) and aimed primarily at early career researchers.
 

--- a/content/en/resources/external/using-digital-archives-for-historical-research/index.mdx
+++ b/content/en/resources/external/using-digital-archives-for-historical-research/index.mdx
@@ -32,7 +32,6 @@ remote:
   publication-date: 2021-02-23
   url: https://doi.org/10.7486/DRI.r4958772q
   publisher: Digital Repository of Ireland
-doi: https://hdl.handle.net/21.11159/019595c4-42d0-72b8-b9ca-68d96f7549f2
 ---
 This video recording is of "Using Digital Archives for Historical Research", the **first** webinar in a three-part public lecture series on using digital archives for academic research hosted by the Digital Repository of Ireland (DRI) and aimed primarily at early career researchers.
 

--- a/content/en/resources/external/using-digital-archives-for-social-sciences-research/index.mdx
+++ b/content/en/resources/external/using-digital-archives-for-social-sciences-research/index.mdx
@@ -32,7 +32,6 @@ remote:
   publication-date: 2021-04-20
   url: https://doi.org/10.7486/DRI.bg25n363c
   publisher: Digital Repository of Ireland
-doi: https://hdl.handle.net/21.11159/019595c4-4303-76af-a514-a779ae40ad29
 ---
 This screencast is of "Using Digital Archives for Social Sciences Research", the **third** and final webinar in a three-part public lecture series on using digital archives for academic research hosted by the Digital Repository of Ireland (DRI) and aimed primarily at early career researchers.
 

--- a/content/en/resources/external/using-named-entity-recognition-to-enhance-access-to-a-museum-catalog/index.mdx
+++ b/content/en/resources/external/using-named-entity-recognition-to-enhance-access-to-a-museum-catalog/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2018-08-27
   url: https://blog.ehri-project.eu/2018/08/27/named-entity-recognition/
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-4330-754b-b6c2-4836e7960c32
 ---
 Digital technologies have been successfully applied in cultural heritage projects that support the digitization of cultural objects, metadata creation, metadata maintenance, and the creation of digital infrastructure for cultural heritage research, to name a few. When we discuss archival digital textual content, some of the most immediate tasks relate to automatic metadata generation, searchability, and preservation, all of which can be helped by services for automatic semantic annotation.
 

--- a/content/en/resources/external/using-opencv-for-face-detection/index.mdx
+++ b/content/en/resources/external/using-opencv-for-face-detection/index.mdx
@@ -25,7 +25,6 @@ remote:
   publication-date: 2019-08-27
   url: https://github.com/EHRI/ehri-data-analysis-tools/tree/master/face_detection_with_opencv
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-435b-720c-80b5-f53096236fa2
 ---
 OpenCV is a very popular, free and open source software system used for a large variety of computer vision applications. This article is intended to help you get started in experimenting with OpenCV, using an example of face detection in images as a case study.
 

--- a/content/en/resources/external/using-spatial-data-in-tableau/index.mdx
+++ b/content/en/resources/external/using-spatial-data-in-tableau/index.mdx
@@ -25,7 +25,6 @@ remote:
   publication-date: 2019-08-15
   url: https://github.com/EHRI/ehri-data-analysis-tools/tree/master/tableau
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-4389-76da-8bed-67ea77335677
 ---
 Tableau is a powerful digital tool for analysing data. In this short guide we will focus on an aspect of data analysis using mapping that has particular application for Holocaust and refugee studies. Sometimes just simply mapping your data is not enough, and you want to use other features such as changing the size of a marker above a location in order to demonstrate the number of people from that town or city. Tableau can help with this and can be used for free for 14 days, or is available free of charge to individuals teaching or researching at an academic institution. For more information about Tableau and to download the software see *[https://www.tableau.com/](https://www.tableau.com/)*
 

--- a/content/en/resources/external/virtual-reality-and-the-museum-library-sector-the-case-of-the-university-museum-and-library-of-trondheim/index.mdx
+++ b/content/en/resources/external/virtual-reality-and-the-museum-library-sector-the-case-of-the-university-museum-and-library-of-trondheim/index.mdx
@@ -32,7 +32,6 @@ remote:
   publication-date: 2017-03-28
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-lecture-23
   publisher: Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)
-doi: https://hdl.handle.net/21.11159/019595c4-43bd-76ed-af45-31ef8cd63035
 dariah-national-consortia:
   - at
 ---

--- a/content/en/resources/external/visual-analytics-enabling-images-to-speak-for-themselves/index.mdx
+++ b/content/en/resources/external/visual-analytics-enabling-images-to-speak-for-themselves/index.mdx
@@ -31,7 +31,6 @@ remote:
   publication-date: 2017-05-08
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-lecture-31
   publisher: Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)
-doi: https://hdl.handle.net/21.11159/019595c4-43f0-7659-b01f-130158025218
 dariah-national-consortia:
   - at
 ---

--- a/content/en/resources/external/what-300-dimensional-fridges-can-tell-us-about-language/index.mdx
+++ b/content/en/resources/external/what-300-dimensional-fridges-can-tell-us-about-language/index.mdx
@@ -30,7 +30,6 @@ remote:
   publication-date: 2021-06-16
   url: https://www.oeaw.ac.at/acdh/newsevents/event-series/acdh-ch-lecture-72
   publisher: Austrian Centre for Digital Humanities and Cultural Heritage (ACDH-CH)
-doi: https://hdl.handle.net/21.11159/019595c4-4426-761c-a7df-bc85b016feec
 dariah-national-consortia:
   - at
 ---

--- a/content/en/resources/external/what-can-i-do-with-this-messy-spreadsheet-converting-from-excel-sheets-to-fully-compliant-ead-xml-files/index.mdx
+++ b/content/en/resources/external/what-can-i-do-with-this-messy-spreadsheet-converting-from-excel-sheets-to-fully-compliant-ead-xml-files/index.mdx
@@ -35,7 +35,6 @@ remote:
   publication-date: 2022-04-25
   url: https://blog.ehri-project.eu/2022/04/25/converting-from-excel-to-ead-xml/
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-445a-74a3-84a5-ce40f636818d
 ---
 Many Galleries, Libraries, Archives, and Museums (GLAM) face difficulties sharing their collections meta-data in standardised and sustainable ways due to the absence of in-house Information Technology (IT) support or capabilities. This situation means that staff rely on more familiar general purpose office programs like text processors, spreadsheets, or low-code databases. However, while these tools offer an easy approach to data registration and digitisation, they don't allow for more advanced uses. This blog explains a procedure for producing EAD (Encoded Archival Description) files from an Excel spreadsheet using OpenRefine.
 

--- a/content/en/resources/external/wikipedia-as-a-source-of-historical-knowledge-applying-digital-source-criticism/index.mdx
+++ b/content/en/resources/external/wikipedia-as-a-source-of-historical-knowledge-applying-digital-source-criticism/index.mdx
@@ -33,7 +33,6 @@ remote:
   url: https://ranke2.uni.lu/u/wikipedia-historical-source/
   publisher: Ranke.2, Centre for Contemporary and Digital History (C²DH),
     University of Luxembourg
-doi: https://hdl.handle.net/21.11159/019595c4-448b-7719-ab2e-7bafcb30d9b0
 dariah-national-consortia:
   - lu
 ---

--- a/content/en/resources/external/windows-subsystem-for-linux-wsl-a-convenient-way-to-run-linux-tools-on-a-windows-10-system/index.mdx
+++ b/content/en/resources/external/windows-subsystem-for-linux-wsl-a-convenient-way-to-run-linux-tools-on-a-windows-10-system/index.mdx
@@ -30,7 +30,6 @@ remote:
   publication-date: 2019-08-15
   url: https://github.com/EHRI/ehri-data-analysis-tools/tree/master/installing_linux_on_windows
   publisher: EHRI
-doi: https://hdl.handle.net/21.11159/019595c4-44c2-704b-87cc-0186e2d0ddb8
 ---
 Linux is a popular operating system and is especially useful for projects involving command-line scripts and programming languages such as Python. Many tools and examples that are of interest to those wishing to explore, experiment, and develop projects for digital humanities or data analysis and other tasks are based on Linux. Mac laptops support Linux fairly easily, and there are many online resources that a Mac user may find helpful. However, until recently, people who have only Windows computers have had a relatively difficult time in accessing programs and techniques that require a Linux operating system.
 

--- a/content/en/resources/external/working-with-named-places-how-and-why-to-build-a-gazetteer/index.mdx
+++ b/content/en/resources/external/working-with-named-places-how-and-why-to-build-a-gazetteer/index.mdx
@@ -27,7 +27,6 @@ remote:
   publication-date: 2024-03-27
   url: https://doi.org/10.46430/phen0117
   publisher: ProgHist Ltd
-doi: https://hdl.handle.net/21.11159/019595c4-44ee-77e0-82c2-deff5495e0bb
 ---
 This lesson teaches you how to leverage the power of digital gazetteers, which are essential resources for spatial history. Unlike maps, gazetteers can readily connect named spatial entities with one another and with their modern locations, and they make it easy to annotate any identified place with information about texts, events, people, or other places that have been associated with it.
 

--- a/content/en/resources/hosted/3-d-acquisition-technique-and-aware-heritage-modelling/index.mdx
+++ b/content/en/resources/hosted/3-d-acquisition-technique-and-aware-heritage-modelling/index.mdx
@@ -14,21 +14,20 @@ tags:
   - 3d-modelling
 sources:
   - artemis
-featured-image: >-
-  /assets/content/assets/en/resources/hosted/3-d-acquisition-technique-and-aware-heritage-modelling/featured-image.png
+featured-image: /assets/content/assets/en/resources/hosted/3-d-acquisition-technique-and-aware-heritage-modelling/featured-image.png
 license: cc-by-4.0
 table-of-contents: false
 summary:
-  content: >-
-    This resource introduces the basic concepts of 3D modelling for cultural
-    heritage, focusing on 3D acquisition techniques and the broader concept of
-    Aware Heritage Modelling. Three modelling approaches are presented:
-    source-based, reality-based and hybrid. In addition,the course addresses the
-    role of critical documentation, AI and FAIR principles.
+  content: "This resource introduces the basic concepts of 3D modelling for
+    cultural heritage, focusing on 3D acquisition techniques and the broader
+    concept of Aware Heritage Modelling. Three modelling approaches are
+    presented: source-based, reality-based and hybrid. In addition,the course
+    addresses the role of critical documentation, AI and FAIR principles."
 content-type: video
 translations: []
 dariah-national-consortia: []
 dariah-working-groups: []
+doi: https://hdl.handle.net/21.11159/019f607b-6139-777b-983c-a769cc9fbd6f
 ---
 This resource introduces the basic concepts of 3D modelling for cultural heritage, focusing on 3D acquisition techniques and the broader concept of Aware Heritage Modelling. First, the three main modelling approaches are defined: source-based, reality-based, and hybrid. The focus then shifts to reality-based modelling, presenting the most widespread techniques — range-based, image-based, and topographic methods — through their instruments, workflows, strengths, and limits. AI-based techniques are briefly presented as emerging tools that can complement traditional methods. Finally, the need for a critical and aware approach is stressed, in which 3D reconstruction becomes a documented, interoperable and reusable knowledge base, grounded in metadata, paradata, and FAIR principles.
 

--- a/content/en/resources/hosted/can-this-be-done-new-research-tools-for-studying-human-interaction/index.mdx
+++ b/content/en/resources/hosted/can-this-be-done-new-research-tools-for-studying-human-interaction/index.mdx
@@ -27,6 +27,7 @@ translations: []
 dariah-national-consortia:
   - se
 dariah-working-groups: []
+doi: https://hdl.handle.net/21.11159/019f607b-6350-7216-8a57-86609662e3cd
 ---
 In this webinar, Stefan Lindgren and Carolina Larsson (Lund University Humanities Lab) demonstrated a new workflow for using motion capture to study human movement and interaction. The workflow arose from a collaboration with Riksteatern Crea, a theatre group in Sweden that creates stage productions in sign language designed for deaf, hard-of-hearing, and hearing audiences alike. They asked whether it is possible to transfer the complex movements of a sign-language performer to a digital avatar that could be projected onto a stage and interact in real time with both the audience and live actors. The answer was yes. Here, Lindgren and Larsson outline the development of a simplified, more efficient workflow for researchers studying human interaction through body movement and gesture using motion capture devices of different kinds and a free game developing software called Unreal Engine.
 

--- a/content/en/resources/hosted/designing-and-integrating-an-io-ct-node-sensor-integration-and-data-flows-for-a-reactive-heritage-digital-twin/index.mdx
+++ b/content/en/resources/hosted/designing-and-integrating-an-io-ct-node-sensor-integration-and-data-flows-for-a-reactive-heritage-digital-twin/index.mdx
@@ -1,7 +1,6 @@
 ---
-title: >-
-  Designing and Integrating an IoCT Node: Sensor Integration and Data Flows for
-  a Reactive Heritage Digital Twin
+title: "Designing and Integrating an IoCT Node: Sensor Integration and Data
+  Flows for a Reactive Heritage Digital Twin"
 locale: en
 publication-date: 2026-05-15
 version: 1.0.0
@@ -14,19 +13,18 @@ tags:
   - cultural-heritage
 sources:
   - artemis
-featured-image: >-
-  /assets/content/assets/en/resources/hosted/designing-and-integrating-an-io-ct-node-sensor-integration-and-data-flows-for-a-reactive-heritage-digital-twin/featured-image.png
+featured-image: /assets/content/assets/en/resources/hosted/designing-and-integrating-an-io-ct-node-sensor-integration-and-data-flows-for-a-reactive-heritage-digital-twin/featured-image.png
 license: cc-by-4.0
 table-of-contents: false
 summary:
-  content: >-
-    The resource explores how IoCT technologies power Reactive Digital Twins in
-    ARTEMIS, transforming real-time data into intelligent actions for cultural
-    heritage monitoring and protection.
+  content: The resource explores how IoCT technologies power Reactive Digital
+    Twins in ARTEMIS, transforming real-time data into intelligent actions for
+    cultural heritage monitoring and protection.
 content-type: video
 translations: []
 dariah-national-consortia: []
 dariah-working-groups: []
+doi: https://hdl.handle.net/21.11159/019f607b-6382-73c7-a053-137232867824
 ---
 This resource presents the design and integration of Internet of Cultural Things technologies (IoCT) within the ARTEMIS ecosystem, highlighting their key role in enabling Reactive Heritage Digital Twins (RHDT).
 

--- a/content/en/resources/hosted/designing-the-backbone-of-the-rhdt-using-ai-and-network-science/index.mdx
+++ b/content/en/resources/hosted/designing-the-backbone-of-the-rhdt-using-ai-and-network-science/index.mdx
@@ -15,13 +15,11 @@ tags:
   - information-retrieval
 sources:
   - artemis
-featured-image: >-
-  /assets/content/assets/en/resources/hosted/designing-the-backbone-of-the-rhdt-using-ai-and-network-science/featured-image.png
+featured-image: /assets/content/assets/en/resources/hosted/designing-the-backbone-of-the-rhdt-using-ai-and-network-science/featured-image.png
 license: cc-by-4.0
 table-of-contents: false
 summary:
-  content: >-
-    This resource discusses how the ARTEMIS project combines artificial
+  content: This resource discusses how the ARTEMIS project combines artificial
     intelligence, network science, knowledge graphs, and semantic ontologies to
     transform unstructured cultural heritage data into structured,
     machine-readable knowledge supporting Reactive Heritage Digital Twins
@@ -30,6 +28,7 @@ content-type: video
 translations: []
 dariah-national-consortia: []
 dariah-working-groups: []
+doi: https://hdl.handle.net/21.11159/019f607b-63b7-725d-aecf-cad883e74808
 ---
 This resource discusses how the ARTEMIS project combines artificial intelligence, network science, knowledge graphs, and semantic ontologies to transform unstructured cultural heritage data into structured, machine-readable knowledge supporting Reactive Heritage Digital Twins (RHDTs). The presentation explores how technologies such as Natural Language Processing (NLP), Computer Vision, embeddings, and large language models (LLMs) help extract, interpret, and connect information from heterogeneous sources. Particular emphasis is placed on the semi-automatic construction of semantic knowledge structures, highlighting the importance of open-source AI, scalability, and expert human validation in creating reliable and collaborative cultural heritage infrastructure within ARTEMIS.
 

--- a/content/en/resources/hosted/introduction-to-computer-science-cloud-computing-and-beyond/index.mdx
+++ b/content/en/resources/hosted/introduction-to-computer-science-cloud-computing-and-beyond/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Introduction to Computer Science: Cloud Computing and Beyond'
+title: "Introduction to Computer Science: Cloud Computing and Beyond"
 locale: en
 publication-date: 2026-05-14
 version: 1.0.0
@@ -13,8 +13,7 @@ tags:
   - information-retrieval
 sources:
   - artemis
-featured-image: >-
-  /assets/content/assets/en/resources/hosted/introduction-to-computer-science-cloud-computing-and-beyond/featured-image.png
+featured-image: /assets/content/assets/en/resources/hosted/introduction-to-computer-science-cloud-computing-and-beyond/featured-image.png
 license: cc-by-4.0
 table-of-contents: false
 summary:
@@ -27,6 +26,7 @@ content-type: video
 translations: []
 dariah-national-consortia: []
 dariah-working-groups: []
+doi: https://hdl.handle.net/21.11159/019f607b-63e6-76f1-a3d4-f64450ebaac2
 ---
 This resource introduces the fundamental concepts of cloud computing and discusses its role within the ARTEMIS project as an infrastructure for hosting user-oriented services and managing cultural heritage data, highlighting the main cloud service models.
 

--- a/content/en/resources/hosted/mytholudics-games-and-myth/index.mdx
+++ b/content/en/resources/hosted/mytholudics-games-and-myth/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: ' Mytholudics: Games and Myth'
+title: " Mytholudics: Games and Myth"
 locale: en
 publication-date: 2026-06-24
 version: 1.0.0
@@ -25,6 +25,7 @@ content-type: webinar-recording
 translations: []
 dariah-national-consortia: []
 dariah-working-groups: []
+doi: https://hdl.handle.net/21.11159/019f607b-6415-7417-8d7e-34914a91866c
 ---
 Games create worlds made of many different elements, but also of rules, systems and structures for how we act in them. So how can we make sense of them? Mytholudics: Games and Myth lays out an approach to understanding games using theories from myth and folklore. Myth is understood not as an object or a kind of story, but as a way of expressing meaning, a way in which we produce a model for understanding the world and things in it. This webinar from the Friday Frontier series lays out this approach and how it can help you analyse and conceptualise gameworlds. The framework helps to see games and their worlds in the whole. Stories, gameplay, systems, rules, spatial configurations and art styles can all be considered together as contributing to the meaning of the game.
 

--- a/content/en/resources/hosted/strategic-validation-in-complex-spatial-simulation-projects/index.mdx
+++ b/content/en/resources/hosted/strategic-validation-in-complex-spatial-simulation-projects/index.mdx
@@ -13,21 +13,20 @@ tags:
   - project-management
 sources:
   - artemis
-featured-image: >-
-  /assets/content/assets/en/resources/hosted/strategic-validation-in-complex-spatial-simulation-projects/featured-image.png
+featured-image: /assets/content/assets/en/resources/hosted/strategic-validation-in-complex-spatial-simulation-projects/featured-image.png
 license: cc-by-4.0
 table-of-contents: false
 summary:
-  content: >-
-    This resource explores the challenges of validation within complex spatial
-    simulation projects. Drawing on practical examples connected to ARTEMIS
-    activities, the session discusses how complexity emerges from interconnected
-    data flows, historical accuracy requirements, simulation layers, and
-    collaborative workflows.
+  content: This resource explores the challenges of validation within complex
+    spatial simulation projects. Drawing on practical examples connected to
+    ARTEMIS activities, the session discusses how complexity emerges from
+    interconnected data flows, historical accuracy requirements, simulation
+    layers, and collaborative workflows.
 content-type: video
 translations: []
 dariah-national-consortia: []
 dariah-working-groups: []
+doi: https://hdl.handle.net/21.11159/019f607b-6448-715f-8095-29c5bc415365
 ---
 This resource explores the challenges of validation within complex spatial simulation projects. Drawing on practical examples connected to ARTEMIS activities, the session discusses how complexity emerges from interconnected data flows, historical accuracy requirements, simulation layers, and collaborative workflows. 
 

--- a/content/en/resources/hosted/the-intelligent-twin-understanding-the-past-navigating-the-future-with-ai/index.mdx
+++ b/content/en/resources/hosted/the-intelligent-twin-understanding-the-past-navigating-the-future-with-ai/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'The Intelligent Twin: Understanding the Past, Navigating the Future with AI '
+title: "The Intelligent Twin: Understanding the Past, Navigating the Future with AI "
 locale: en
 publication-date: 2026-05-15
 version: 1.0.0
@@ -14,8 +14,7 @@ tags:
   - natural-language-processing
 sources:
   - artemis
-featured-image: >-
-  /assets/content/assets/en/resources/hosted/the-intelligent-twin-understanding-the-past-navigating-the-future-with-ai/featured-image.png
+featured-image: /assets/content/assets/en/resources/hosted/the-intelligent-twin-understanding-the-past-navigating-the-future-with-ai/featured-image.png
 license: cc-by-4.0
 table-of-contents: false
 summary:
@@ -29,6 +28,7 @@ content-type: video
 translations: []
 dariah-national-consortia: []
 dariah-working-groups: []
+doi: https://hdl.handle.net/21.11159/019f607b-6477-717c-ad31-fd8bc85e0cc1
 ---
 This resource provides an overview of how Artificial Intelligence (AI) and semantic technologies can support the development of Intelligent Digital Twins for cultural heritage. It explores semantic search systems, vector embeddings, predictive modelling, and simulation environments capable of transforming fragmented datasets into accessible and meaningful knowledge. Particular emphasis is placed on natural language querying, similarity-based discovery of hidden relationships between cultural heritage objects, and the role of structured, interoperable data infrastructures in making heritage information more intuitive and accessible for both experts and non-technical users.
 

--- a/scripts/api/generate-metadata-dump.ts
+++ b/scripts/api/generate-metadata-dump.ts
@@ -178,6 +178,8 @@ export async function createMetadata(): Promise<{
 
 					resources.push({
 						...resource,
+						/** External resources are hosted elsewhere and are not assigned a handle pid. */
+						pid: null,
 						external: {
 							"publication-date": external.metadata.remote["publication-date"],
 							url: external.metadata.remote.url,

--- a/scripts/api/metadata-schemas.ts
+++ b/scripts/api/metadata-schemas.ts
@@ -69,6 +69,8 @@ const externalResourceSchema = v.object({
 	...baseResourceFields,
 	collection: v.literal("resourcesExternal"),
 	kind: v.literal("external"),
+	/** External resources are hosted elsewhere and are not assigned a handle pid. */
+	pid: v.null(),
 	external: v.object({
 		url: v.string(),
 		"publication-date": v.string(),

--- a/scripts/handle/create-handle.sh
+++ b/scripts/handle/create-handle.sh
@@ -17,7 +17,9 @@ if [[ -n "${files}" ]]; then
     --header "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/${repo}/pulls?head=${VERCEL_GIT_REPO_OWNER}:${branch}&base=main&state=open")
 
-  if [[ "${existing_pr}" != "[]" ]]; then
+  # The GitHub API returns an empty result set as "[\n\n]", not a literal "[]",
+  # so match on an actual pull request field instead of comparing the raw body.
+  if echo "${existing_pr}" | grep -q '"number"'; then
     echo "Pull request already exists for ${branch}."
     exit 0
   fi

--- a/scripts/handle/create-handle.sh
+++ b/scripts/handle/create-handle.sh
@@ -8,7 +8,7 @@ fi
 branch="content/add-handle-${VERCEL_GIT_COMMIT_SHA:0:12}"
 repo="${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}"
 
-files=$(git diff --diff-filter=AMR --name-only ${VERCEL_GIT_PREVIOUS_SHA} ${VERCEL_GIT_COMMIT_SHA} -- 'content/*/curricula/**/index.mdx' 'content/*/resources/**/index.mdx' | xargs)
+files=$(git diff --diff-filter=AMR --name-only ${VERCEL_GIT_PREVIOUS_SHA} ${VERCEL_GIT_COMMIT_SHA} -- 'content/*/curricula/**/index.mdx' 'content/*/resources/**/index.mdx' ':(exclude)content/*/resources/external/**' | xargs)
 
 if [[ -n "${files}" ]]; then
   existing_pr=$(curl --fail --silent \

--- a/scripts/handle/create-handle.ts
+++ b/scripts/handle/create-handle.ts
@@ -27,6 +27,11 @@ async function create() {
 	const args = parseArgs({ options: { resource: { type: "string", short: "r" } } });
 	const { resource: path } = v.parse(ArgsInputSchema, args.values);
 
+	/** External resources are hosted elsewhere and must not be assigned a handle. */
+	if (/[/\\]resources[/\\]external[/\\]/.test(path)) {
+		return null;
+	}
+
 	const absoluteFilePath = join(process.cwd(), path);
 	const vfile = await read(absoluteFilePath, { encoding: "utf-8" });
 	matter(vfile, { strip: true });


### PR DESCRIPTION
- adapt the script to no longer mint handles for external resources
- unlist handles from existing external resources
- already minted handles for external resources still resolve to their campus urls - we may want to point them to a tombstone or delete them altogether

closes #1797