### PR TITLE
feat: add image hotspot widget

### DIFF
--- a/app/_lib/fonts.ts
+++ b/app/_lib/fonts.ts
@@ -1,7 +1,7 @@
 import { Fira_Code, Roboto } from "next/font/google";
 
 export const body = Roboto({
-	style: ["normal"],
+	style: ["normal", "italic"],
 	subsets: ["latin"],
 	variable: "--_font-body",
 });

--- a/components/content/quiz-controls.tsx
+++ b/components/content/quiz-controls.tsx
@@ -9,7 +9,7 @@ import { useQuizContext } from "@/components/content/quiz";
 interface QuizControlsProps {
 	nextButtonLabel: string;
 	previousButtonLabel: string;
-	validateButtonLabel: string;
+	validateButtonLabel?: string;
 }
 
 export function QuizControls(props: Readonly<QuizControlsProps>): ReactNode {
@@ -24,9 +24,11 @@ export function QuizControls(props: Readonly<QuizControlsProps>): ReactNode {
 				<span>{previousButtonLabel}</span>
 			</Button>
 
-			<Button type="submit">
-				<span>{validateButtonLabel}</span>
-			</Button>
+			{validateButtonLabel != null ? (
+				<Button type="submit">
+					<span>{validateButtonLabel}</span>
+				</Button>
+			) : null}
 
 			<Button isDisabled={!navigation.hasNext} onPress={navigation.next}>
 				<span>{nextButtonLabel}</span>

--- a/components/content/quiz-image-hotspots.tsx
+++ b/components/content/quiz-image-hotspots.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { assert } from "@acdh-oeaw/lib";
+import cn from "clsx/lite";
+import { MapPinIcon, XIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+	Children,
+	createContext,
+	type CSSProperties,
+	type ReactNode,
+	use,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import {
+	Button,
+	Dialog,
+	DialogTrigger,
+	Modal,
+	ModalOverlay,
+	OverlayArrow,
+	Popover,
+} from "react-aria-components";
+import { createPortal } from "react-dom";
+
+import { useQuizContext } from "@/components/content/quiz";
+import { QuizControls } from "@/components/content/quiz-controls";
+import { Image } from "@/components/image";
+
+type HotspotPresentation = "inline" | "popover" | "sidepanel";
+
+interface HotspotContextValue {
+	activeId: string | null;
+	inlinePanel: HTMLElement | null;
+	presentation: HotspotPresentation;
+	select: (id: string | null) => void;
+}
+
+const HotspotContext = createContext<HotspotContextValue | null>(null);
+const HotspotIndexContext = createContext(1);
+
+interface QuizImageHotspotsProps {
+	alt?: string;
+	children: ReactNode;
+	height?: number;
+	presentation?: HotspotPresentation;
+	src: string;
+	width?: number;
+}
+
+export function QuizImageHotspots(props: Readonly<QuizImageHotspotsProps>): ReactNode {
+	const { alt = "", children, height, presentation = "inline", src, width } = props;
+	const { isCurrent } = useQuizContext();
+	const t = useTranslations("content.QuizControls");
+	const hotspotsT = useTranslations("content.QuizImageHotspots");
+	const [activeId, setActiveId] = useState<string | null>(null);
+	const [inlinePanel, setInlinePanel] = useState<HTMLElement | null>(null);
+	const contextValue = useMemo(() => {
+		return { activeId, inlinePanel, presentation, select: setActiveId };
+	}, [activeId, inlinePanel, presentation]);
+	// eslint-disable-next-line @eslint-react/no-children-map -- MDX supplies hotspots as opaque children; wrapping them preserves their elements while providing document order.
+	const indexedHotspotChildren = Children.map(children, (child, index) => {
+		return <HotspotIndexContext value={index + 1}>{child}</HotspotIndexContext>;
+	});
+
+	return (
+		<section
+			className="@container my-4 grid gap-y-4 rounded-md border border-neutral-200 bg-white px-4 py-6 text-sm/relaxed text-neutral-950 shadow-sm"
+			hidden={!isCurrent}
+		>
+			<HotspotContext value={contextValue}>
+				<div
+					className={cn(
+						"not-prose grid gap-4",
+						presentation === "inline"
+							? "@[48rem]:grid-cols-[minmax(0,3fr)_minmax(16rem,2fr)]"
+							: undefined,
+					)}
+				>
+					<div className="relative isolate self-start overflow-hidden rounded-md">
+						<Image alt={alt} className="h-auto w-full" height={height} src={src} width={width} />
+						{indexedHotspotChildren}
+					</div>
+
+					{presentation === "inline" ? (
+						<aside
+							ref={setInlinePanel}
+							aria-label={hotspotsT("inline-panel-label")}
+							className={cn(
+								"max-h-96 min-h-32 overflow-y-auto overscroll-contain rounded-md border border-neutral-200 bg-neutral-50 p-4",
+								activeId == null ? "grid place-items-center" : undefined,
+							)}
+						>
+							{activeId == null ? (
+								<p className="text-center text-neutral-600">{hotspotsT("select-hotspot")}</p>
+							) : null}
+						</aside>
+					) : null}
+				</div>
+			</HotspotContext>
+
+			<QuizControls
+				nextButtonLabel={t("next-question")}
+				previousButtonLabel={t("previous-question")}
+			/>
+		</section>
+	);
+}
+
+interface QuizImageHotspotProps {
+	children: ReactNode;
+	label: string;
+	x: number;
+	y: number;
+}
+
+export function QuizImageHotspot(props: Readonly<QuizImageHotspotProps>): ReactNode {
+	const { children, label, x, y } = props;
+	const context = use(HotspotContext);
+	assert(context != null);
+	const hotspotIndex = use(HotspotIndexContext);
+	const { activeId, inlinePanel, presentation, select } = context;
+	const t = useTranslations("content.QuizImageHotspots");
+	const resolvedLabel = label.trim() || t("hotspot-label", { index: String(hotspotIndex) });
+	const id = useId();
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const isActive = activeId === id;
+	const panelId = `${id}-panel`;
+	const style = { "--hotspot-x": `${String(x)}%`, "--hotspot-y": `${String(y)}%` } as CSSProperties;
+
+	if (presentation === "popover") {
+		return (
+			<DialogTrigger>
+				<Button
+					aria-label={resolvedLabel}
+					className="absolute top-(--hotspot-y) left-(--hotspot-x) grid size-9 -translate-1/2 place-items-center rounded-full border-2 border-white bg-brand-700 text-white shadow-md outline-none transition hover:scale-110 focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2 pressed:scale-95"
+					style={style}
+				>
+					<MapPinIcon aria-hidden={true} className="size-5" />
+				</Button>
+				<Popover
+					className="prose prose-sm max-h-[min(70vh,32rem)] w-80 max-w-[calc(100vw-2rem)] overflow-auto rounded-md border border-neutral-200 bg-white px-4 py-3 text-neutral-950 shadow-lg"
+					offset={12}
+				>
+					<OverlayArrow className="group">
+						<svg
+							aria-hidden={true}
+							className="block fill-white stroke-1 stroke-neutral-200 group-placement-bottom:rotate-180 group-placement-left:-rotate-90 group-placement-right:rotate-90"
+							height={12}
+							viewBox="0 0 12 12"
+							width={12}
+						>
+							<path d="M0 0 L6 6 L12 0" />
+						</svg>
+					</OverlayArrow>
+					<Dialog aria-label={resolvedLabel} className="outline-none">
+						<p className="font-semibold">{resolvedLabel}</p>
+						{children}
+					</Dialog>
+				</Popover>
+			</DialogTrigger>
+		);
+	}
+
+	if (presentation === "sidepanel") {
+		return (
+			<DialogTrigger>
+				<Button
+					aria-label={resolvedLabel}
+					className="absolute top-(--hotspot-y) left-(--hotspot-x) grid size-9 -translate-1/2 place-items-center rounded-full border-2 border-white bg-brand-700 text-white shadow-md outline-none transition hover:scale-110 focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2 pressed:scale-95"
+					style={style}
+				>
+					<MapPinIcon aria-hidden={true} className="size-5" />
+				</Button>
+				<ModalOverlay className="fixed inset-0 z-50 bg-neutral-950/40" isDismissable={true}>
+					<Modal className="fixed inset-y-0 right-0 w-full max-w-xl overflow-y-auto bg-white text-neutral-950 shadow-2xl outline-none">
+						<Dialog aria-label={resolvedLabel} className="min-h-full outline-none">
+							<header className="sticky top-0 z-10 flex items-start justify-between gap-4 border-b border-neutral-200 bg-white px-6 py-4">
+								<h2 className="text-lg font-semibold">{resolvedLabel}</h2>
+								<Button
+									aria-label={t("close")}
+									className="grid size-8 shrink-0 place-items-center rounded-md text-neutral-600 outline-none hover:bg-neutral-100 focus-visible:ring-2 focus-visible:ring-brand-700 pressed:bg-neutral-200"
+									slot="close"
+								>
+									<XIcon aria-hidden={true} className="size-4" />
+								</Button>
+							</header>
+							<div className="prose prose-sm max-w-none px-6 py-5">{children}</div>
+						</Dialog>
+					</Modal>
+				</ModalOverlay>
+			</DialogTrigger>
+		);
+	}
+
+	return (
+		<>
+			<Button
+				ref={triggerRef}
+				aria-controls={panelId}
+				aria-expanded={isActive}
+				aria-label={resolvedLabel}
+				className={cn(
+					"absolute top-(--hotspot-y) left-(--hotspot-x) grid size-9 -translate-1/2 place-items-center rounded-full border-2 border-white bg-brand-700 text-white shadow-md outline-none transition hover:scale-110 focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2 pressed:scale-95",
+					isActive ? "scale-110 bg-brand-900 ring-2 ring-white" : undefined,
+				)}
+				onPress={() => {
+					select(id);
+				}}
+				style={style}
+			>
+				<MapPinIcon aria-hidden={true} className="size-5" />
+			</Button>
+			{isActive && inlinePanel != null
+				? createPortal(
+						<section aria-label={resolvedLabel} className="prose prose-sm" id={panelId}>
+							<header className="not-prose mb-3 flex items-start justify-between gap-3">
+								<p className="font-semibold text-neutral-950">{resolvedLabel}</p>
+								<Button
+									aria-label={t("close")}
+									className="grid size-8 shrink-0 place-items-center rounded-md text-neutral-600 outline-none hover:bg-neutral-200 focus-visible:ring-2 focus-visible:ring-brand-700 pressed:bg-neutral-300"
+									onPress={() => {
+										select(null);
+										triggerRef.current?.focus();
+									}}
+								>
+									<XIcon aria-hidden={true} className="size-4" />
+								</Button>
+							</header>
+							{children}
+						</section>,
+						inlinePanel,
+					)
+				: null}
+		</>
+	);
+}

--- a/components/content/quiz.tsx
+++ b/components/content/quiz.tsx
@@ -34,6 +34,8 @@ export function Quiz(props: Readonly<QuizProps>): ReactNode {
 
 	const [currentIndex, setCurrentIndex] = useState(0);
 
+	if (quizzes.length === 0) return null;
+
 	const value: Omit<QuizContextValue, "isCurrent"> = {
 		navigation: {
 			hasNext: currentIndex < quizzes.length - 1,

--- a/lib/content/collections/curricula.ts
+++ b/lib/content/collections/curricula.ts
@@ -38,7 +38,7 @@ const compileOptions: CompileOptions = {
 		createCustomHeadingIdsPlugin(),
 		createHeadingIdsPlugin(),
 		createIframeTitlesPlugin(["Embed", "Video"]),
-		createImageSizesPlugin(["Figure", "VideoCard"]),
+		createImageSizesPlugin(["Figure", "QuizImageHotspots", "VideoCard"]),
 		createMermaidDiagramsPlugin(),
 		createSyntaxHighlighterPlugin(),
 		createTableOfContentsPlugin(),

--- a/lib/content/collections/documentation.ts
+++ b/lib/content/collections/documentation.ts
@@ -35,7 +35,7 @@ const compileOptions: CompileOptions = {
 		createCustomHeadingIdsPlugin(),
 		createHeadingIdsPlugin(),
 		createIframeTitlesPlugin(["Embed", "Video"]),
-		createImageSizesPlugin(["Figure", "VideoCard"]),
+		createImageSizesPlugin(["Figure", "QuizImageHotspots", "VideoCard"]),
 		createMermaidDiagramsPlugin(),
 		createSyntaxHighlighterPlugin(),
 		createTableOfContentsPlugin(),

--- a/lib/content/collections/resources/external.ts
+++ b/lib/content/collections/resources/external.ts
@@ -36,7 +36,7 @@ const compileOptions: CompileOptions = {
 		createCustomHeadingIdsPlugin(),
 		createHeadingIdsPlugin(),
 		createIframeTitlesPlugin(["Embed", "Video"]),
-		createImageSizesPlugin(["Figure", "VideoCard"]),
+		createImageSizesPlugin(["Figure", "QuizImageHotspots", "VideoCard"]),
 		createMermaidDiagramsPlugin(),
 		createSyntaxHighlighterPlugin(),
 		createTableOfContentsPlugin(),

--- a/lib/content/collections/resources/hosted.ts
+++ b/lib/content/collections/resources/hosted.ts
@@ -40,7 +40,7 @@ const compileOptions: CompileOptions = {
 		createCustomHeadingIdsPlugin(),
 		createHeadingIdsPlugin(),
 		createIframeTitlesPlugin(["Embed", "Video"]),
-		createImageSizesPlugin(["Figure", "VideoCard"]),
+		createImageSizesPlugin(["Figure", "QuizImageHotspots", "VideoCard"]),
 		createMermaidDiagramsPlugin(),
 		createSyntaxHighlighterPlugin(),
 		createTableOfContentsPlugin(),

--- a/lib/content/github-client/index.ts
+++ b/lib/content/github-client/index.ts
@@ -54,7 +54,7 @@ const createEvaluateOptions = (baseUrl: string) => {
 			createSyntaxHighlighterPlugin(),
 			createTableOfContentsPlugin(),
 			createUnwrappedMdxFlowContentPlugin(["LinkButton"]),
-			createRemoteImageUrlsPlugin(baseUrl, ["Figure", "VideoCard"]),
+			createRemoteImageUrlsPlugin(baseUrl, ["Figure", "QuizImageHotspots", "VideoCard"]),
 		],
 	} satisfies EvaluateOptions;
 };

--- a/lib/content/keystatic/components/quiz/image-hotspots-preview.tsx
+++ b/lib/content/keystatic/components/quiz/image-hotspots-preview.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/* eslint-disable react/jsx-no-literals */
+
+import { useObjectUrl, type UseObjectUrlParams } from "@acdh-oeaw/keystatic-lib/preview";
+import { Button } from "@keystar/ui/button";
+import { NotEditable } from "@keystatic/core";
+import cn from "clsx/lite";
+import { MapPinIcon } from "lucide-react";
+import {
+	type CSSProperties,
+	type PointerEvent as ReactPointerEvent,
+	type ReactNode,
+	useCallback,
+	useRef,
+	useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+interface QuizImageHotspotsPreviewProps {
+	alt?: string;
+	children: ReactNode;
+	src: UseObjectUrlParams | null;
+}
+
+export function QuizImageHotspotsPreview(
+	props: Readonly<QuizImageHotspotsPreviewProps>,
+): ReactNode {
+	const { alt = "", children, src } = props;
+	const url = useObjectUrl(src);
+
+	return (
+		<figure className="grid gap-y-3 rounded-md border border-neutral-200 p-3">
+			<NotEditable>
+				<div
+					className="relative isolate min-h-12 overflow-hidden rounded-md"
+					data-hotspot-overlay=""
+				>
+					{url != null ? (
+						// eslint-disable-next-line @next/next/no-img-element
+						<img alt={alt} className="h-auto w-full" draggable={false} src={url} />
+					) : (
+						<div className="grid min-h-32 place-items-center bg-neutral-100 text-neutral-500">
+							Choose an image to place hotspots.
+						</div>
+					)}
+				</div>
+			</NotEditable>
+			<figcaption>
+				<div aria-label="Hotspots" className="grid gap-y-3" role="list">
+					{children}
+				</div>
+			</figcaption>
+		</figure>
+	);
+}
+
+interface QuizImageHotspotValue {
+	label: string;
+	x: number | null;
+	y: number | null;
+}
+
+interface QuizImageHotspotEditorProps {
+	children?: ReactNode;
+	isSelected: boolean;
+	onChange: (value: QuizImageHotspotValue) => void;
+	onEditChildren?: () => void;
+	onSelect: () => void;
+	value: QuizImageHotspotValue;
+}
+
+export function QuizImageHotspotEditor(props: Readonly<QuizImageHotspotEditorProps>): ReactNode {
+	const { children, isSelected, onChange, onEditChildren, onSelect, value } = props;
+	const dragStateRef = useRef<{
+		hasMoved: boolean;
+		pointerId: number;
+		startX: number;
+		startY: number;
+	} | null>(null);
+	const [overlay, setOverlay] = useState<HTMLElement | null>(null);
+	const x = value.x ?? 50;
+	const y = value.y ?? 50;
+	const initCard = useCallback((element: HTMLDivElement | null) => {
+		const overlay = element
+			?.closest("figure")
+			?.querySelector<HTMLElement>("[data-hotspot-overlay]");
+		setOverlay(overlay ?? null);
+	}, []);
+	const style = {
+		"--hotspot-x": `${String(x)}%`,
+		"--hotspot-y": `${String(y)}%`,
+	} as CSSProperties;
+
+	function getPosition(clientX: number, clientY: number): { x: number; y: number } | null {
+		if (overlay == null) return null;
+
+		const bounds = overlay.getBoundingClientRect();
+		const x = Math.min(Math.max(((clientX - bounds.left) / bounds.width) * 100, 0), 100);
+		const y = Math.min(Math.max(((clientY - bounds.top) / bounds.height) * 100, 0), 100);
+
+		return { x: Math.round(x * 10) / 10, y: Math.round(y * 10) / 10 };
+	}
+
+	function previewPointerPosition(event: ReactPointerEvent<HTMLButtonElement>): void {
+		const position = getPosition(event.clientX, event.clientY);
+		if (position == null) return;
+
+		event.currentTarget.style.setProperty("--hotspot-x", `${String(position.x)}%`);
+		event.currentTarget.style.setProperty("--hotspot-y", `${String(position.y)}%`);
+	}
+
+	const marker =
+		overlay == null
+			? null
+			: createPortal(
+					<button
+						aria-label={`Move hotspot: ${value.label || "Untitled hotspot"}`}
+						className={cn(
+							"absolute top-(--hotspot-y) left-(--hotspot-x) grid size-9 -translate-1/2 touch-none place-items-center rounded-full border-2 border-white bg-brand-700 text-white shadow-md outline-none transition hover:scale-110 focus-visible:ring-2 focus-visible:ring-brand-700 focus-visible:ring-offset-2",
+							isSelected ? "scale-125 bg-brand-900 ring-4 ring-brand-300" : undefined,
+						)}
+						onFocus={onSelect}
+						onKeyDown={(event) => {
+							const step = event.shiftKey ? 5 : 1;
+							const movement = {
+								ArrowDown: [0, step],
+								ArrowLeft: [-step, 0],
+								ArrowRight: [step, 0],
+								ArrowUp: [0, -step],
+							}[event.key];
+
+							if (movement == null) return;
+							event.preventDefault();
+							onChange({
+								...value,
+								x: Math.min(Math.max(x + movement[0]!, 0), 100),
+								y: Math.min(Math.max(y + movement[1]!, 0), 100),
+							});
+						}}
+						onPointerDown={(event) => {
+							if (event.button !== 0) return;
+							onSelect();
+							event.preventDefault();
+							event.stopPropagation();
+							event.currentTarget.setPointerCapture(event.pointerId);
+							dragStateRef.current = {
+								hasMoved: false,
+								pointerId: event.pointerId,
+								startX: event.clientX,
+								startY: event.clientY,
+							};
+						}}
+						onPointerMove={(event) => {
+							if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+							const drag = dragStateRef.current;
+							if (drag?.pointerId !== event.pointerId) return;
+
+							if (!drag.hasMoved) {
+								const deltaX = event.clientX - drag.startX;
+								const deltaY = event.clientY - drag.startY;
+								if (Math.hypot(deltaX, deltaY) < 4) return;
+								drag.hasMoved = true;
+							}
+							previewPointerPosition(event);
+						}}
+						onPointerUp={(event) => {
+							if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+							const hasMoved = dragStateRef.current?.hasMoved === true;
+							event.currentTarget.releasePointerCapture(event.pointerId);
+							dragStateRef.current = null;
+							if (!hasMoved) return;
+
+							const position = getPosition(event.clientX, event.clientY);
+							if (position != null) onChange({ ...value, ...position });
+						}}
+						style={style}
+						type="button"
+					>
+						<MapPinIcon aria-hidden={true} className="size-5" />
+					</button>,
+					overlay,
+				);
+
+	return (
+		// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- Pointer convenience; the pin and Edit button provide keyboard selection.
+		<div
+			ref={initCard}
+			className={cn(
+				"cursor-default rounded-md border bg-(--kui-color-background-surface) p-3 text-(--kui-color-foreground-neutral-emphasis) transition",
+				isSelected
+					? "border-(--kui-color-alias-border-selected) ring-2 ring-(--kui-color-alias-focus-ring)"
+					: "border-(--kui-color-alias-border-idle) hover:border-(--kui-color-alias-border-hovered)",
+			)}
+			onClick={onSelect}
+			role="listitem"
+		>
+			<NotEditable>
+				{marker}
+				<div className="flex items-center justify-between gap-x-3">
+					<p className="min-w-0 flex-1 truncate text-sm font-medium">
+						{value.label || "Untitled hotspot"} ({x.toFixed(1)}%, {y.toFixed(1)}%)
+					</p>
+					{onEditChildren != null ? (
+						<Button onFocus={onSelect} onPress={onEditChildren} prominence="low">
+							Edit
+						</Button>
+					) : null}
+				</div>
+			</NotEditable>
+			{children != null ? (
+				<div className="mt-3 min-h-20 border-t border-(--kui-color-alias-border-idle) pt-3">
+					{children}
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/lib/content/keystatic/components/quiz/index.tsx
+++ b/lib/content/keystatic/components/quiz/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @eslint-react/prefer-read-only-props */
 
-import { createComponent } from "@acdh-oeaw/keystatic-lib";
+import { createAssetOptions, createComponent } from "@acdh-oeaw/keystatic-lib";
 import { fields } from "@keystatic/core";
 import { repeating, wrapper } from "@keystatic/core/content-components";
 import { MessageCircleQuestionIcon } from "lucide-react";
@@ -10,18 +10,19 @@ import {
 	QuizChoicePreview,
 	QuizChoiceQuestionPreview,
 	QuizErrorMessagePreview,
+	QuizImageHotspotEditor,
+	QuizImageHotspotsPreview,
 	QuizPreview,
 	QuizSuccessMessagePreview,
 } from "@/lib/content/keystatic/components/quiz/preview";
 
-export const createQuiz = createComponent((_paths, _locale) => {
+export const createQuiz = createComponent((paths, _locale) => {
 	return {
 		Quiz: repeating({
 			label: "Quiz",
 			description: "An interactive quiz.",
 			icon: <MessageCircleQuestionIcon />,
-			children: ["QuizChoice"],
-			validation: { children: { min: 1 } },
+			children: ["QuizChoice", "QuizImageHotspots"],
 			schema: {},
 			ContentView(props) {
 				const { children } = props;
@@ -64,6 +65,76 @@ export const createQuiz = createComponent((_paths, _locale) => {
 						{children}
 					</QuizChoicePreview>
 				);
+			},
+		}),
+		QuizImageHotspots: repeating({
+			label: "Quiz - Image hotspots",
+			description: "An image with points that reveal explanatory content.",
+			icon: <MessageCircleQuestionIcon />,
+			forSpecificLocations: true,
+			children: ["QuizImageHotspot"],
+			validation: { children: { min: 1 } },
+			schema: {
+				src: fields.image({
+					label: "Image",
+					validation: { isRequired: true },
+					...createAssetOptions(paths.assetPath),
+				}),
+				alt: fields.text({
+					label: "Image description for assistive technology",
+					description:
+						"Describe the image and the relevant spatial information; leave empty only if the image is decorative.",
+					validation: { isRequired: false },
+				}),
+				presentation: fields.select({
+					label: "Hotspot content presentation",
+					description:
+						"Inline panels sit beside or below the image. Modal side panels provide more room for longer content. Anchored popovers work best for short explanations.",
+					options: [
+						{ label: "Inline panel", value: "inline" },
+						{ label: "Modal side panel", value: "sidepanel" },
+						{ label: "Anchored popover", value: "popover" },
+					],
+					defaultValue: "inline",
+				}),
+			},
+			ContentView(props) {
+				const { children, value } = props;
+
+				return (
+					<QuizImageHotspotsPreview alt={value.alt} src={value.src}>
+						{children}
+					</QuizImageHotspotsPreview>
+				);
+			},
+		}),
+		QuizImageHotspot: wrapper({
+			label: "Image hotspot",
+			description: "A point on the image that opens explanatory content.",
+			icon: <MessageCircleQuestionIcon />,
+			forSpecificLocations: true,
+			editChildrenIn: "modal",
+			schema: {
+				label: fields.text({
+					label: "Hotspot label",
+					description: "Identifies the hotspot to screen-reader users and titles its popover.",
+					validation: { isRequired: true },
+				}),
+				x: fields.number({
+					label: "Horizontal position (%)",
+					defaultValue: 50,
+					step: 0.1,
+					validation: { isRequired: true, min: 0, max: 100 },
+				}),
+				y: fields.number({
+					label: "Vertical position (%)",
+					defaultValue: 50,
+					step: 0.1,
+					validation: { isRequired: true, min: 0, max: 100 },
+				}),
+			},
+			NodeView(props) {
+				return <QuizImageHotspotEditor {...props} />;
 			},
 		}),
 		QuizChoiceAnswer: wrapper({

--- a/lib/content/keystatic/components/quiz/preview.tsx
+++ b/lib/content/keystatic/components/quiz/preview.tsx
@@ -3,6 +3,11 @@
 import { NotEditable } from "@keystatic/core";
 import type { ReactNode } from "react";
 
+export {
+	QuizImageHotspotEditor,
+	QuizImageHotspotsPreview,
+} from "@/lib/content/keystatic/components/quiz/image-hotspots-preview";
+
 interface QuizPreviewProps {
 	children: ReactNode;
 }

--- a/lib/content/mdx/components.tsx
+++ b/lib/content/mdx/components.tsx
@@ -13,6 +13,7 @@ import { LinkButton } from "@/components/content/link-button";
 import { MermaidDiagram } from "@/components/content/mermaid-diagram";
 import { Quiz, QuizErrorMessage, QuizSuccessMessage } from "@/components/content/quiz";
 import { QuizChoice, QuizChoiceAnswer, QuizChoiceQuestion } from "@/components/content/quiz-choice";
+import { QuizImageHotspot, QuizImageHotspots } from "@/components/content/quiz-image-hotspots";
 import { TableOfContents } from "@/components/content/table-of-contents";
 import { Tab, Tabs } from "@/components/content/tabs";
 import { Video } from "@/components/content/video";
@@ -46,6 +47,8 @@ export const components = {
 	QuizChoiceAnswer,
 	QuizChoiceQuestion,
 	QuizErrorMessage,
+	QuizImageHotspot,
+	QuizImageHotspots,
 	QuizSuccessMessage,
 	Tab,
 	TableOfContents,

--- a/messages/en.json
+++ b/messages/en.json
@@ -20,6 +20,12 @@
 			"score": "{correct} / {total} correct",
 			"show-solution": "Show solution"
 		},
+		"QuizImageHotspots": {
+			"close": "Close annotation",
+			"hotspot-label": "Hotspot {index}",
+			"inline-panel-label": "Image annotation",
+			"select-hotspot": "Select a point on the image to view its annotation."
+		},
 		"QuizControls": {
 			"correct": "Correct!",
 			"incorrect": "Incorrect!",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"@acdh-oeaw/openapi-nextjs": "^0.0.3",
 		"@acdh-oeaw/style-variants": "^0.1.0",
 		"@acdh-oeaw/validate-env": "^0.2.1",
+		"@keystar/ui": "0.7.21",
 		"@keystatic/core": "0.5.49",
 		"@keystatic/next": "^5.0.4",
 		"@mdx-js/mdx": "^3.1.1",

--- a/patches/@keystatic__core.patch
+++ b/patches/@keystatic__core.patch
@@ -1,3 +1,439 @@
+diff --git a/dist/index-4767f7d9.js b/dist/index-4767f7d9.js
+--- a/dist/index-4767f7d9.js
++++ b/dist/index-4767f7d9.js
+@@ -19844,7 +19844,7 @@
+   } = useDialogContainer();
+   return /*#__PURE__*/jsxs(Fragment, {
+     children: [/*#__PURE__*/jsx(Content, {
+-      children: /*#__PURE__*/jsx(Flex, {
++      children: /*#__PURE__*/jsxs(Flex, {
+         id: formId,
+         elementType: "form",
+         onSubmit: event => {
+@@ -19859,10 +19859,10 @@
+         },
+         direction: "column",
+         gap: "xxlarge",
+-        children: /*#__PURE__*/jsx(FormValueContentFromPreviewProps, {
++        children: [/*#__PURE__*/jsx(FormValueContentFromPreviewProps, {
+           ...previewProps,
+           forceValidation: forceValidation
+-        })
++        }), props.children]
+       })
+     }), /*#__PURE__*/jsxs(ButtonGroup, {
+       children: [/*#__PURE__*/jsx(Button, {
+@@ -20139,26 +20139,113 @@
+     return false;
+   }
+ }
++function WrapperEditDialog(props) {
++  const [childrenValue, setChildrenValue] = useState(() => props.editChildren ? createEditorState(props.node.type.schema.topNodeType.create(null, props.node.content)) : null);
++  return /*#__PURE__*/jsxs(Dialog, {
++    children: [/*#__PURE__*/jsxs(Heading, {
++      children: ["Edit ", props.component.label]
++    }), /*#__PURE__*/jsx(FormValue, {
++      schema: props.schema,
++      value: props.value,
++      onSave: value => {
++        props.runCommand((state, dispatch) => {
++          if (dispatch) {
++            const pos = props.getPos();
++            const currentNode = state.doc.nodeAt(pos);
++            if (!currentNode) return false;
++            let tr = state.tr.setNodeAttribute(pos, "props", toSerialized(value, props.schema.fields));
++            if (childrenValue) {
++              tr = tr.replaceWith(pos + 1, pos + currentNode.nodeSize - 1, childrenValue.doc.content);
++            }
++            dispatch(tr);
++          }
++          return true;
++        });
++      },
++      children: childrenValue && /*#__PURE__*/jsx(Box, {
++        border: "color.alias.borderIdle",
++        borderRadius: "medium",
++        overflow: "hidden",
++        children: /*#__PURE__*/jsx(Editor, {
++          value: childrenValue,
++          onChange: setChildrenValue,
++          "aria-label": `${props.component.label} content`
++        })
++      })
++    })]
++  });
++}
++function HiddenWrapperChildren(props) {
++  return /*#__PURE__*/jsx("div", {
++    hidden: true,
++    children: props.children
++  });
++}
++function CustomWrapperNodeView(props) {
++  const [isOpen, setIsOpen] = useState(false);
++  const runCommand = useEditorDispatchCommand();
++  const editorViewRef = useEditorViewRef();
++  const value = useDeserializedValue(props.node.attrs.props, props.component.schema);
++  const schema = {
++    kind: "object",
++    fields: props.component.schema
++  };
++  const editChildren = props.component.editChildrenIn === "modal";
++  const NodeView = props.component.NodeView;
++  return /*#__PURE__*/jsxs(Fragment, {
++    children: [/*#__PURE__*/jsx(NodeView, {
++      isSelected: props.hasNodeSelection,
++      onRemove: () => {
++        runCommand((state, dispatch) => {
++          if (dispatch) {
++            const pos = props.getPos();
++            dispatch(state.tr.delete(pos, pos + props.node.nodeSize));
++          }
++          return true;
++        });
++      },
++      onChange: value => {
++        runCommand((state, dispatch) => {
++          if (dispatch) {
++            dispatch(state.tr.setNodeAttribute(props.getPos(), "props", toSerialized(value, schema.fields)));
++          }
++          return true;
++        });
++      },
++      onEditChildren: editChildren ? () => setIsOpen(true) : undefined,
++      onSelect: () => {
++        const view = editorViewRef.current;
++        if (!view) return;
++        view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, props.getPos())));
++      },
++      value: value,
++      children: editChildren ? null : props.children
++    }), editChildren && /*#__PURE__*/jsx(HiddenWrapperChildren, {
++      children: props.children
++    }), /*#__PURE__*/jsx(DialogContainer, {
++      onDismiss: () => setIsOpen(false),
++      children: isOpen && /*#__PURE__*/jsx(WrapperEditDialog, {
++        component: props.component,
++        editChildren: true,
++        getPos: props.getPos,
++        node: props.node,
++        runCommand: runCommand,
++        schema: schema,
++        value: value
++      })
++    })]
++  });
++}
+ function BlockWrapper(props) {
+-  const $ = c(37);
+   const [isOpen, setIsOpen] = useState(false);
+   const runCommand = useEditorDispatchCommand();
+-  let t0;
+-  let t1;
+-  if ($[0] !== props.component.schema) {
+-    t1 = {
+-      kind: "object",
+-      fields: props.component.schema
+-    };
+-    $[0] = props.component.schema;
+-    $[1] = t1;
+-  } else {
+-    t1 = $[1];
+-  }
+-  t0 = t1;
+-  const schema = t0;
++  const schema = {
++    kind: "object",
++    fields: props.component.schema
++  };
+   const value = useDeserializedValue(props.node.attrs.props, props.component.schema);
+-  const t2 = `${classes.blockParent} ${css({
++  const editChildren = props.component.kind === "wrapper" && props.component.editChildrenIn === "modal";
++  const className = `${classes.blockParent} ${css({
+     marginBlock: "1em",
+     position: "relative",
+     ...(props.hasNodeSelection ? {
+@@ -20172,175 +20259,61 @@
+       }
+     } : {})
+   })}${props.hasNodeSelection ? ` ${classes.hideselection}` : ""}`;
+-  const t3 = props.hasNodeSelection ? "color.alias.borderSelected" : "color.alias.borderDisabled";
+-  const t4 = props.hasNodeSelection ? "color.alias.backgroundSelected" : "color.alias.backgroundIdle";
+-  const t5 = props.hasNodeSelection ? tokenSchema.color.foreground.accent : tokenSchema.color.foreground.neutralTertiary;
+-  let t6;
+-  if ($[2] !== t5) {
+-    t6 = css({
+-      color: t5,
+-      textTransform: "uppercase",
+-      fontWeight: tokenSchema.typography.fontWeight.semibold,
+-      fontSize: "0.9rem"
+-    });
+-    $[2] = t5;
+-    $[3] = t6;
+-  } else {
+-    t6 = $[3];
+-  }
+-  let t7;
+-  if ($[4] !== runCommand || $[5] !== props) {
+-    t7 = () => {
+-      runCommand((state, dispatch) => {
+-        if (dispatch) {
+-          dispatch(state.tr.setSelection(NodeSelection.create(state.doc, props.getPos())));
+-        }
+-        return true;
+-      });
+-    };
+-    $[4] = runCommand;
+-    $[5] = props;
+-    $[6] = t7;
+-  } else {
+-    t7 = $[6];
+-  }
+-  let t8;
+-  if ($[7] !== t6 || $[8] !== t7 || $[9] !== props.component.label) {
+-    t8 = /*#__PURE__*/jsx(Box, {
+-      flex: 1,
+-      paddingX: "regular",
+-      paddingY: "small",
+-      UNSAFE_className: t6,
+-      onClick: t7,
+-      children: props.component.label
+-    });
+-    $[7] = t6;
+-    $[8] = t7;
+-    $[9] = props.component.label;
+-    $[10] = t8;
+-  } else {
+-    t8 = $[10];
+-  }
+-  let t9;
+-  if ($[11] !== props.component.schema) {
+-    t9 = !!Object.keys(props.component.schema).length && /*#__PURE__*/jsx(Button, {
+-      prominence: "low",
+-      onPress: () => {
+-        setIsOpen(true);
+-      },
+-      UNSAFE_className: css({
+-        borderBottomRightRadius: 0
+-      }),
+-      children: "Edit"
+-    });
+-    $[11] = props.component.schema;
+-    $[12] = t9;
+-  } else {
+-    t9 = $[12];
+-  }
+-  let t10;
+-  if ($[13] !== t4 || $[14] !== t8 || $[15] !== props.toolbar || $[16] !== t9) {
+-    t10 = /*#__PURE__*/jsxs(Flex, {
+-      backgroundColor: t4,
+-      contentEditable: false,
+-      alignItems: "center",
+-      "data-ignore-content": "",
+-      children: [t8, props.toolbar, t9]
+-    });
+-    $[13] = t4;
+-    $[14] = t8;
+-    $[15] = props.toolbar;
+-    $[16] = t9;
+-    $[17] = t10;
+-  } else {
+-    t10 = $[17];
+-  }
+-  let t11;
+-  if ($[18] !== props.children) {
+-    t11 = /*#__PURE__*/jsx(Box, {
+-      padding: "regular",
+-      children: props.children
+-    });
+-    $[18] = props.children;
+-    $[19] = t11;
+-  } else {
+-    t11 = $[19];
+-  }
+-  let t12;
+-  if ($[20] !== t2 || $[21] !== t3 || $[22] !== t10 || $[23] !== t11) {
+-    t12 = /*#__PURE__*/jsxs(Box, {
+-      UNSAFE_className: t2,
+-      border: t3,
++  const labelClassName = css({
++    color: props.hasNodeSelection ? tokenSchema.color.foreground.accent : tokenSchema.color.foreground.neutralTertiary,
++    textTransform: "uppercase",
++    fontWeight: tokenSchema.typography.fontWeight.semibold,
++    fontSize: "0.9rem"
++  });
++  return /*#__PURE__*/jsxs(Fragment, {
++    children: [/*#__PURE__*/jsxs(Box, {
++      UNSAFE_className: className,
++      border: props.hasNodeSelection ? "color.alias.borderSelected" : "color.alias.borderDisabled",
+       borderRadius: "regular",
+-      children: [t10, t11]
+-    });
+-    $[20] = t2;
+-    $[21] = t3;
+-    $[22] = t10;
+-    $[23] = t11;
+-    $[24] = t12;
+-  } else {
+-    t12 = $[24];
+-  }
+-  let t13;
+-  if ($[25] === Symbol.for("react.memo_cache_sentinel")) {
+-    t13 = () => {
+-      setIsOpen(false);
+-    };
+-    $[25] = t13;
+-  } else {
+-    t13 = $[25];
+-  }
+-  let t14;
+-  if ($[26] !== isOpen || $[27] !== props || $[28] !== runCommand || $[29] !== schema || $[30] !== value) {
+-    t14 = isOpen && /*#__PURE__*/jsxs(Dialog, {
+-      children: [/*#__PURE__*/jsxs(Heading, {
+-        children: ["Edit ", props.component.label]
+-      }), /*#__PURE__*/jsx(FormValue, {
+-        schema: schema,
+-        value: value,
+-        onSave: value_0 => {
+-          runCommand((state_0, dispatch_0) => {
+-            if (dispatch_0) {
+-              dispatch_0(state_0.tr.setNodeAttribute(props.getPos(), "props", toSerialized(value_0, schema.fields)));
+-            }
+-            return true;
+-          });
+-        }
++      children: [/*#__PURE__*/jsxs(Flex, {
++        backgroundColor: props.hasNodeSelection ? "color.alias.backgroundSelected" : "color.alias.backgroundIdle",
++        contentEditable: false,
++        alignItems: "center",
++        "data-ignore-content": "",
++        children: [/*#__PURE__*/jsx(Box, {
++          flex: 1,
++          paddingX: "regular",
++          paddingY: "small",
++          UNSAFE_className: labelClassName,
++          onClick: () => {
++            runCommand((state, dispatch) => {
++              if (dispatch) dispatch(state.tr.setSelection(NodeSelection.create(state.doc, props.getPos())));
++              return true;
++            });
++          },
++          children: props.component.label
++        }), props.toolbar, (!!Object.keys(props.component.schema).length || editChildren) && /*#__PURE__*/jsx(Button, {
++          prominence: "low",
++          onPress: () => setIsOpen(true),
++          UNSAFE_className: css({
++            borderBottomRightRadius: 0
++          }),
++          children: "Edit"
++        })]
++      }), editChildren ? /*#__PURE__*/jsx(HiddenWrapperChildren, {
++        children: props.children
++      }) : /*#__PURE__*/jsx(Box, {
++        padding: "regular",
++        children: props.children
+       })]
+-    });
+-    $[26] = isOpen;
+-    $[27] = props;
+-    $[28] = runCommand;
+-    $[29] = schema;
+-    $[30] = value;
+-    $[31] = t14;
+-  } else {
+-    t14 = $[31];
+-  }
+-  let t15;
+-  if ($[32] !== t14) {
+-    t15 = /*#__PURE__*/jsx(DialogContainer, {
+-      onDismiss: t13,
+-      children: t14
+-    });
+-    $[32] = t14;
+-    $[33] = t15;
+-  } else {
+-    t15 = $[33];
+-  }
+-  let t16;
+-  if ($[34] !== t12 || $[35] !== t15) {
+-    t16 = /*#__PURE__*/jsxs(Fragment, {
+-      children: [t12, t15]
+-    });
+-    $[34] = t12;
+-    $[35] = t15;
+-    $[36] = t16;
+-  } else {
+-    t16 = $[36];
+-  }
+-  return t16;
++    }), /*#__PURE__*/jsx(DialogContainer, {
++      onDismiss: () => setIsOpen(false),
++      children: isOpen && /*#__PURE__*/jsx(WrapperEditDialog, {
++        component: props.component,
++        editChildren: editChildren,
++        getPos: props.getPos,
++        node: props.node,
++        runCommand: runCommand,
++        schema: schema,
++        value: value
++      })
++    })]
++  });
+ }
+ function getCustomNodeSpecs(components) {
+   const componentNames = new Map(Object.keys(components).map((name, i) => [name, `component${i}`]));
+@@ -20430,26 +20403,11 @@
+           component: function Block(props) {
+             const runCommand = useEditorDispatchCommand();
+             const value = useDeserializedValue(props.node.attrs.props, component.schema);
+-            return 'NodeView' in component && component.NodeView ? /*#__PURE__*/jsx(component.NodeView, {
+-              isSelected: props.hasNodeSelection || props.isNodeCompletelyWithinSelection,
+-              onRemove: () => {
+-                runCommand((state, dispatch) => {
+-                  if (dispatch) {
+-                    const pos = props.getPos();
+-                    dispatch(state.tr.delete(pos, pos + props.node.nodeSize));
+-                  }
+-                  return true;
+-                });
+-              },
+-              onChange: value => {
+-                runCommand((state, dispatch) => {
+-                  if (dispatch) {
+-                    dispatch(state.tr.setNodeAttribute(props.getPos(), 'props', toSerialized(value, schema.fields)));
+-                  }
+-                  return true;
+-                });
+-              },
+-              value: value,
++            return 'NodeView' in component && component.NodeView ? /*#__PURE__*/jsx(CustomWrapperNodeView, {
++              component: component,
++              getPos: props.getPos,
++              hasNodeSelection: props.hasNodeSelection || props.isNodeCompletelyWithinSelection,
++              node: props.node,
+               children: props.children
+             }) : /*#__PURE__*/jsx(BlockWrapper, {
+               node: props.node,
+diff --git a/dist/declarations/src/content-components.d.ts b/dist/declarations/src/content-components.d.ts
+--- a/dist/declarations/src/content-components.d.ts
++++ b/dist/declarations/src/content-components.d.ts
+@@ -7,6 +7,7 @@
+     icon?: ReactElement;
+     schema: Schema;
+     forSpecificLocations?: boolean;
++    editChildrenIn?: 'inline' | 'modal';
+ } & ({
+     ContentView?: (props: {
+         value: ParsedValueForComponentSchema<ObjectField<Schema>>;
+@@ -17,6 +18,8 @@
+         value: ParsedValueForComponentSchema<ObjectField<Schema>>;
+         onChange(value: ParsedValueForComponentSchema<ObjectField<Schema>>): void;
+         onRemove(): void;
++        onEditChildren?(): void;
++        onSelect(): void;
+         isSelected: boolean;
+         children: ReactNode;
+     }) => ReactNode;
 diff --git a/dist/keystatic-core-ui.js b/dist/keystatic-core-ui.js
 index 24d47136e7317bab8f460a8eab537a5bbd0072c0..364c640755c0e665d493703513745846b84d0b11 100644
 --- a/dist/keystatic-core-ui.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@keystatic/core': e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8
+  '@keystatic/core': 1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b
   next: de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624
 
 importers:
@@ -14,7 +14,7 @@ importers:
     dependencies:
       '@acdh-oeaw/keystatic-lib':
         specifier: ^0.8.0
-        version: 0.8.0(@keystar/ui@0.7.21(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@keystatic/core@0.5.49(patch_hash=e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 0.8.0(@keystar/ui@0.7.21(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@keystatic/core@0.5.49(patch_hash=1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@acdh-oeaw/lib':
         specifier: ^0.3.7
         version: 0.3.7
@@ -30,12 +30,15 @@ importers:
       '@acdh-oeaw/validate-env':
         specifier: ^0.2.1
         version: 0.2.1(typescript@5.9.3)
+      '@keystar/ui':
+        specifier: 0.7.21
+        version: 0.7.21(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@keystatic/core':
         specifier: 0.5.49
-        version: 0.5.49(patch_hash=e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.5.49(patch_hash=1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@keystatic/next':
         specifier: ^5.0.4
-        version: 5.0.4(@keystatic/core@0.5.49(patch_hash=e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 5.0.4(@keystatic/core@0.5.49(patch_hash=1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@mdx-js/mdx':
         specifier: ^3.1.1
         version: 3.1.1
@@ -6914,10 +6917,10 @@ snapshots:
       - eslint-plugin-import
       - supports-color
 
-  '@acdh-oeaw/keystatic-lib@0.8.0(@keystar/ui@0.7.21(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@keystatic/core@0.5.49(patch_hash=e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@acdh-oeaw/keystatic-lib@0.8.0(@keystar/ui@0.7.21(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@keystatic/core@0.5.49(patch_hash=1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@keystar/ui': 0.7.21(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@keystatic/core': 0.5.49(patch_hash=e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@keystatic/core': 0.5.49(patch_hash=1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@sindresorhus/slugify': 2.2.1
       '@types/mdx': 2.0.13
       react: 19.2.6
@@ -7902,7 +7905,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@keystatic/core@0.5.49(patch_hash=e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@keystatic/core@0.5.49(patch_hash=1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.28.3
       '@braintree/sanitize-url': 6.0.4
@@ -7980,10 +7983,10 @@ snapshots:
       - next
       - supports-color
 
-  '@keystatic/next@5.0.4(@keystatic/core@0.5.49(patch_hash=e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@keystatic/next@5.0.4(@keystatic/core@0.5.49(patch_hash=1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.28.3
-      '@keystatic/core': 0.5.49(patch_hash=e8ecc614f19e2b604d774a5b36d3dfb78da533b183e327a981464b0be67afaa8)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@keystatic/core': 0.5.49(patch_hash=1728fca355c0606dde603c9be52425dc5a427ccaecb25a862c73238d8e50183b)(next@16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react': 19.2.14
       chokidar: 3.6.0
       next: 16.2.6(patch_hash=de17907a43a1b46b5534a9628cc7b229f5c0cce5a5f7b19baa0dde85ba1b7624)(@babel/core@7.28.3)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
closes #1701

keystatic patch was necessary to be able to edit richtext, which should be part of the main document (serialized as child node of QuizImageHotspot component) in a dialog (on submit replaces the prosemirror node).

currently rendered as part of Quiz container - needs decision if we should treat it as a quiz, which it not really is.