### PR TITLE
feat: add dedicated details pages for people and topics

### DIFF
--- a/app/(app)/(default)/people/[id]/opengraph-image.tsx
+++ b/app/(app)/(default)/people/[id]/opengraph-image.tsx
@@ -1,0 +1,34 @@
+import { getLocale } from "next-intl/server";
+import { notFound } from "next/navigation";
+import type { ImageResponse } from "next/og";
+
+import { MetadataImage } from "#/components/metadata-image.tsx";
+import { createClient } from "#/lib/content/create-client.ts";
+
+interface OpenGraphImageProps extends PageProps<"/people/[id]"> {}
+
+export const size = {
+	width: 1200,
+	height: 630,
+};
+
+export default async function OpenGraphImage(props: Readonly<OpenGraphImageProps>): Promise<ImageResponse> {
+	const { params } = props;
+
+	const locale = await getLocale();
+
+	const { id: _id } = await params;
+	const id = decodeURIComponent(_id);
+
+	const client = await createClient();
+
+	const person = await client.collections.people.get(id);
+
+	if (person == null) {
+		notFound();
+	}
+
+	const { name } = person.metadata;
+
+	return MetadataImage({ locale, size, title: name });
+}

--- a/app/(app)/(default)/people/[id]/page.tsx
+++ b/app/(app)/(default)/people/[id]/page.tsx
@@ -1,0 +1,145 @@
+import { assert } from "@acdh-oeaw/lib";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { PageLead } from "#/components/page-lead.tsx";
+import { PageTitle } from "#/components/page-title.tsx";
+import { ResourcesGrid } from "#/components/resources-grid.tsx";
+import { client } from "#/lib/content/client/index.ts";
+import { createClient } from "#/lib/content/create-client.ts";
+
+interface PersonPageProps extends PageProps<"/people/[id]"> {}
+
+export async function generateStaticParams(): Promise<Array<Pick<Awaited<PersonPageProps["params"]>, "id">>> {
+	const ids = await client.collections.people.ids();
+
+	return ids.map((id) => {
+		return { id };
+	});
+}
+
+export async function generateMetadata(props: Readonly<PersonPageProps>): Promise<Metadata> {
+	const { params } = props;
+
+	const { id: _id } = await params;
+	const id = decodeURIComponent(_id);
+
+	const client = await createClient();
+
+	const person = await client.collections.people.get(id);
+
+	if (person == null) {
+		notFound();
+	}
+
+	const { name } = person.metadata;
+
+	const metadata: Metadata = {
+		title: name,
+	};
+
+	return metadata;
+}
+
+export default async function PersonPage(props: Readonly<PersonPageProps>): Promise<ReactNode> {
+	const { params } = props;
+
+	const t = await getTranslations("PersonPage");
+
+	const { id: _id } = await params;
+	const id = decodeURIComponent(_id);
+
+	const client = await createClient();
+
+	const person = await client.collections.people.get(id);
+
+	if (person == null) {
+		notFound();
+	}
+
+	const { name } = person.metadata;
+	const Content = person.content;
+
+	const curricula = await Promise.all(
+		person.curricula.map(async (id) => {
+			const curriculum = await client.collections.curricula.get(id);
+			assert(curriculum, `Missing curriculum "${id}".`);
+			const { "content-type": contentType, editors, locale, summary, title } = curriculum.metadata;
+
+			const people = await Promise.all(
+				editors.map(async (id) => {
+					const person = await client.collections.people.get(id);
+					assert(person, `Missing person "${id}".`);
+					const { image, name } = person.metadata;
+					return { id, name, image };
+				}),
+			);
+
+			return {
+				id: curriculum.id,
+				collection: "curricula",
+				contentType,
+				href: curriculum.href,
+				locale,
+				people,
+				summary,
+				title,
+			} as const;
+		}),
+	);
+
+	const items = await Promise.all(
+		person.resources.map(async (id) => {
+			const resource = await client.collections.resources.get(id);
+			assert(resource, `Missing resource "${id}".`);
+			const { authors, locale, summary, title } = resource.metadata;
+
+			const people = await Promise.all(
+				authors.map(async (id) => {
+					const person = await client.collections.people.get(id);
+					assert(person, `Missing person "${id}".`);
+					const { image, name } = person.metadata;
+					return { id, name, image };
+				}),
+			);
+
+			const isDraft = "draft" in resource.metadata && resource.metadata.draft === true;
+
+			const href = isDraft ? null : resource.href;
+
+			return {
+				id: resource.id,
+				collection: `resources-${resource.kind}`,
+				contentType: resource.metadata["content-type"],
+				href,
+				locale,
+				people,
+				summary,
+				title,
+			} as const;
+		}),
+	);
+
+	return (
+		<div className="mx-auto grid content-start gap-y-12 px-4 py-8 inline-full max-inline-7xl xs:px-8 xs:py-16 md:py-24">
+			<div className="grid gap-y-4">
+				<PageTitle>{name}</PageTitle>
+				<PageLead>
+					<Content />
+				</PageLead>
+			</div>
+			{curricula.length > 0 ? (
+				<section className="space-y-5">
+					<h2 className="text-2xl font-bold">{t("curricula")}</h2>
+					<ResourcesGrid peopleLabel={t("editors")} resources={curricula} />
+				</section>
+			) : null}
+			<section className="space-y-5">
+				<h2 className={curricula.length > 0 ? "text-2xl font-bold" : "sr-only"}>{t("resources")}</h2>
+				<ResourcesGrid peopleLabel={t("authors")} resources={items} />
+			</section>
+		</div>
+	);
+}

--- a/app/(app)/(default)/people/[id]/page.tsx
+++ b/app/(app)/(default)/people/[id]/page.tsx
@@ -4,9 +4,10 @@ import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
 
-import { PageLead } from "#/components/page-lead.tsx";
+import { Image } from "#/components/image.tsx";
 import { PageTitle } from "#/components/page-title.tsx";
 import { ResourcesGrid } from "#/components/resources-grid.tsx";
+import { SocialMediaLinks } from "#/components/social-media-links.tsx";
 import { client } from "#/lib/content/client/index.ts";
 import { createClient } from "#/lib/content/create-client.ts";
 
@@ -59,7 +60,7 @@ export default async function PersonPage(props: Readonly<PersonPageProps>): Prom
 		notFound();
 	}
 
-	const { name } = person.metadata;
+	const { image, name, social } = person.metadata;
 	const Content = person.content;
 
 	const curricula = await Promise.all(
@@ -124,12 +125,24 @@ export default async function PersonPage(props: Readonly<PersonPageProps>): Prom
 
 	return (
 		<div className="mx-auto grid content-start gap-y-12 px-4 py-8 inline-full max-inline-7xl xs:px-8 xs:py-16 md:py-24">
-			<div className="grid gap-y-4">
+			<header className="grid justify-items-center gap-y-6 text-center">
+				<Image
+					alt=""
+					className="rounded-full border border-neutral-200 object-cover block-32 inline-32"
+					height={128}
+					src={image}
+					width={128}
+				/>
 				<PageTitle>{name}</PageTitle>
-				<PageLead>
-					<Content />
-				</PageLead>
-			</div>
+				{social.length > 0 ? <SocialMediaLinks social={social} /> : null}
+			</header>
+			{person.hasContent ? (
+				<div className="mx-auto inline-full max-inline-(--size-content)">
+					<div className="prose">
+						<Content />
+					</div>
+				</div>
+			) : null}
 			{curricula.length > 0 ? (
 				<section className="space-y-5">
 					<h2 className="text-2xl font-bold">{t("curricula")}</h2>

--- a/app/(app)/(default)/topics/[id]/opengraph-image.tsx
+++ b/app/(app)/(default)/topics/[id]/opengraph-image.tsx
@@ -1,0 +1,34 @@
+import { getLocale } from "next-intl/server";
+import { notFound } from "next/navigation";
+import type { ImageResponse } from "next/og";
+
+import { MetadataImage } from "#/components/metadata-image.tsx";
+import { createClient } from "#/lib/content/create-client.ts";
+
+interface OpenGraphImageProps extends PageProps<"/topics/[id]"> {}
+
+export const size = {
+	width: 1200,
+	height: 630,
+};
+
+export default async function OpenGraphImage(props: Readonly<OpenGraphImageProps>): Promise<ImageResponse> {
+	const { params } = props;
+
+	const locale = await getLocale();
+
+	const { id: _id } = await params;
+	const id = decodeURIComponent(_id);
+
+	const client = await createClient();
+
+	const tag = await client.collections.tags.get(id);
+
+	if (tag == null) {
+		notFound();
+	}
+
+	const { name } = tag.metadata;
+
+	return MetadataImage({ locale, size, title: name });
+}

--- a/app/(app)/(default)/topics/[id]/page.tsx
+++ b/app/(app)/(default)/topics/[id]/page.tsx
@@ -1,0 +1,145 @@
+import { assert } from "@acdh-oeaw/lib";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { PageLead } from "#/components/page-lead.tsx";
+import { PageTitle } from "#/components/page-title.tsx";
+import { ResourcesGrid } from "#/components/resources-grid.tsx";
+import { client } from "#/lib/content/client/index.ts";
+import { createClient } from "#/lib/content/create-client.ts";
+
+interface TopicPageProps extends PageProps<"/topics/[id]"> {}
+
+export async function generateStaticParams(): Promise<Array<Pick<Awaited<TopicPageProps["params"]>, "id">>> {
+	const ids = await client.collections.tags.ids();
+
+	return ids.map((id) => {
+		return { id };
+	});
+}
+
+export async function generateMetadata(props: Readonly<TopicPageProps>): Promise<Metadata> {
+	const { params } = props;
+
+	const { id: _id } = await params;
+	const id = decodeURIComponent(_id);
+
+	const client = await createClient();
+
+	const tag = await client.collections.tags.get(id);
+
+	if (tag == null) {
+		notFound();
+	}
+
+	const { name } = tag.metadata;
+
+	const metadata: Metadata = {
+		title: name,
+	};
+
+	return metadata;
+}
+
+export default async function TopicPage(props: Readonly<TopicPageProps>): Promise<ReactNode> {
+	const { params } = props;
+
+	const t = await getTranslations("TopicPage");
+
+	const { id: _id } = await params;
+	const id = decodeURIComponent(_id);
+
+	const client = await createClient();
+
+	const tag = await client.collections.tags.get(id);
+
+	if (tag == null) {
+		notFound();
+	}
+
+	const { name } = tag.metadata;
+	const Content = tag.content;
+
+	const curricula = await Promise.all(
+		tag.curricula.map(async (id) => {
+			const curriculum = await client.collections.curricula.get(id);
+			assert(curriculum, `Missing curriculum "${id}".`);
+			const { "content-type": contentType, editors, locale, summary, title } = curriculum.metadata;
+
+			const people = await Promise.all(
+				editors.map(async (id) => {
+					const person = await client.collections.people.get(id);
+					assert(person, `Missing person "${id}".`);
+					const { image, name } = person.metadata;
+					return { id, name, image };
+				}),
+			);
+
+			return {
+				id: curriculum.id,
+				collection: "curricula",
+				contentType,
+				href: curriculum.href,
+				locale,
+				people,
+				summary,
+				title,
+			} as const;
+		}),
+	);
+
+	const items = await Promise.all(
+		tag.resources.map(async (id) => {
+			const resource = await client.collections.resources.get(id);
+			assert(resource, `Missing resource "${id}".`);
+			const { authors, locale, summary, title } = resource.metadata;
+
+			const people = await Promise.all(
+				authors.map(async (id) => {
+					const person = await client.collections.people.get(id);
+					assert(person, `Missing person "${id}".`);
+					const { image, name } = person.metadata;
+					return { id, name, image };
+				}),
+			);
+
+			const isDraft = "draft" in resource.metadata && resource.metadata.draft === true;
+
+			const href = isDraft ? null : resource.href;
+
+			return {
+				id: resource.id,
+				collection: `resources-${resource.kind}`,
+				contentType: resource.metadata["content-type"],
+				href,
+				locale,
+				people,
+				summary,
+				title,
+			} as const;
+		}),
+	);
+
+	return (
+		<div className="mx-auto grid content-start gap-y-12 px-4 py-8 inline-full max-inline-7xl xs:px-8 xs:py-16 md:py-24">
+			<div className="grid gap-y-4">
+				<PageTitle>{name}</PageTitle>
+				<PageLead>
+					<Content />
+				</PageLead>
+			</div>
+			{curricula.length > 0 ? (
+				<section className="space-y-5">
+					<h2 className="text-2xl font-bold">{t("curricula")}</h2>
+					<ResourcesGrid peopleLabel={t("editors")} resources={curricula} />
+				</section>
+			) : null}
+			<section className="space-y-5">
+				<h2 className={curricula.length > 0 ? "text-2xl font-bold" : "sr-only"}>{t("resources")}</h2>
+				<ResourcesGrid peopleLabel={t("authors")} resources={items} />
+			</section>
+		</div>
+	);
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -52,6 +52,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	(await client.collections.sources.all()).map((source) => {
 		routes.push(source.href);
 	});
+	(await client.collections.people.all()).map((person) => {
+		routes.push(person.href);
+	});
+	(await client.collections.tags.all()).map((tag) => {
+		routes.push(tag.href);
+	});
 	(await client.collections.documentation.all()).map((page) => {
 		routes.push(page.href);
 	});

--- a/components/people-list.tsx
+++ b/components/people-list.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 
 import { Image } from "#/components/image.tsx";
 import { Link } from "#/components/link.tsx";
-import { createSearchUrl } from "#/lib/navigation/create-search-url.ts";
 
 const max = 4;
 
@@ -34,7 +33,7 @@ export function PeopleList(props: Readonly<PeopleListProps>): ReactNode {
 						<li key={person.id}>
 							<Link
 								className="inline-flex items-center gap-x-2 leading-none transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-								href={createSearchUrl({ people: [id] })}
+								href={`/people/${id}`}
 							>
 								<Image
 									alt=""
@@ -62,7 +61,7 @@ export function PeopleList(props: Readonly<PeopleListProps>): ReactNode {
 								<li key={person.id}>
 									<Link
 										className="inline-flex items-center gap-x-2 leading-none transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-										href={createSearchUrl({ people: [id] })}
+										href={`/people/${id}`}
 									>
 										<Image
 											alt=""

--- a/components/people.tsx
+++ b/components/people.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 
 import { Image } from "#/components/image.tsx";
 import { Link } from "#/components/link.tsx";
-import { createSearchUrl } from "#/lib/navigation/create-search-url.ts";
 
 const max = 4;
 
@@ -35,7 +34,7 @@ export function People(props: Readonly<PeopleProps>): ReactNode {
 							<li key={id}>
 								<Link
 									className="inline-flex items-center gap-x-2 transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-									href={createSearchUrl({ people: [id] })}
+									href={`/people/${id}`}
 								>
 									<Image
 										alt=""
@@ -63,7 +62,7 @@ export function People(props: Readonly<PeopleProps>): ReactNode {
 									<li key={id}>
 										<Link
 											className="inline-flex items-center gap-x-2 transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-											href={createSearchUrl({ people: [id] })}
+											href={`/people/${id}`}
 										>
 											<Image
 												alt=""

--- a/components/social-media-links.tsx
+++ b/components/social-media-links.tsx
@@ -1,0 +1,66 @@
+import type { FC, ReactNode } from "react";
+
+import {
+	BlueskyIcon,
+	EmailIcon,
+	FacebookIcon,
+	FlickrIcon,
+	GitHubIcon,
+	InstagramIcon,
+	LinkedInIcon,
+	MastodonIcon,
+	OrcidIcon,
+	RssIcon,
+	TwitterIcon,
+	WebsiteIcon,
+	YouTubeIcon,
+} from "#/components/social-media-icons.tsx";
+import type { SocialMediaKind } from "#/lib/content/options.ts";
+
+const logos: Record<SocialMediaKind, FC<{ className?: string }>> = {
+	bluesky: BlueskyIcon,
+	email: EmailIcon,
+	facebook: FacebookIcon,
+	flickr: FlickrIcon,
+	github: GitHubIcon,
+	instagram: InstagramIcon,
+	linkedin: LinkedInIcon,
+	mastodon: MastodonIcon,
+	orcid: OrcidIcon,
+	rss: RssIcon,
+	twitter: TwitterIcon,
+	website: WebsiteIcon,
+	youtube: YouTubeIcon,
+};
+
+interface SocialMediaLinksProps {
+	social: ReadonlyArray<{ discriminant: SocialMediaKind; value: string }>;
+}
+
+/** Inline-level, so it can be centered with `text-center` on an ancestor. */
+export function SocialMediaLinks(props: Readonly<SocialMediaLinksProps>): ReactNode {
+	const { social } = props;
+
+	return (
+		<ul className="inline-flex gap-x-4">
+			{social.map((link, index) => {
+				const { discriminant, value } = link;
+
+				const Logo = logos[discriminant];
+
+				return (
+					<li key={index} className="list-none">
+						<a
+							className="transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
+							/** Email addresses are stored without a scheme. */
+							href={discriminant === "email" ? `mailto:${value}` : value}
+						>
+							<Logo aria-hidden={true} className="inline text-neutral-500 block-5 inline-5" />
+							<span className="sr-only">{discriminant}</span>
+						</a>
+					</li>
+				);
+			})}
+		</ul>
+	);
+}

--- a/components/social-media.tsx
+++ b/components/social-media.tsx
@@ -1,37 +1,7 @@
-import type { FC, ReactNode } from "react";
+import type { ReactNode } from "react";
 
-import {
-	BlueskyIcon,
-	EmailIcon,
-	FacebookIcon,
-	FlickrIcon,
-	GitHubIcon,
-	InstagramIcon,
-	LinkedInIcon,
-	MastodonIcon,
-	OrcidIcon,
-	RssIcon,
-	TwitterIcon,
-	WebsiteIcon,
-	YouTubeIcon,
-} from "#/components/social-media-icons.tsx";
+import { SocialMediaLinks } from "#/components/social-media-links.tsx";
 import type { SocialMediaKind } from "#/lib/content/options.ts";
-
-const logos: Record<SocialMediaKind, FC<{ className?: string }>> = {
-	bluesky: BlueskyIcon,
-	email: EmailIcon,
-	facebook: FacebookIcon,
-	flickr: FlickrIcon,
-	github: GitHubIcon,
-	instagram: InstagramIcon,
-	linkedin: LinkedInIcon,
-	mastodon: MastodonIcon,
-	orcid: OrcidIcon,
-	rss: RssIcon,
-	twitter: TwitterIcon,
-	website: WebsiteIcon,
-	youtube: YouTubeIcon,
-};
 
 interface SocialMediaProps {
 	label: string;
@@ -49,25 +19,7 @@ export function SocialMedia(props: Readonly<SocialMediaProps>): ReactNode {
 		<div className="flex flex-col gap-y-1.5 text-sm text-neutral-500">
 			<div className="text-xs font-bold tracking-wide text-neutral-600 uppercase">{label}</div>
 			<div>
-				<ul className="inline-flex gap-x-4">
-					{social.map((link, index) => {
-						const { discriminant, value } = link;
-
-						const Logo = logos[discriminant];
-
-						return (
-							<li key={index} className="list-none">
-								<a
-									className="transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-									href={value}
-								>
-									<Logo aria-hidden={true} className="inline text-neutral-500 block-5 inline-5" />
-									<span className="sr-only">{discriminant}</span>
-								</a>
-							</li>
-						);
-					})}
-				</ul>
+				<SocialMediaLinks social={social} />
 			</div>
 		</div>
 	);

--- a/components/tags-list.tsx
+++ b/components/tags-list.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
 import { Link } from "#/components/link.tsx";
-import { createSearchUrl } from "#/lib/navigation/create-search-url.ts";
 
 interface TagsListProps {
 	label: ReactNode;
@@ -27,7 +26,7 @@ export function TagsList(props: Readonly<TagsListProps>): ReactNode {
 							<li key={id} className="inline list-none">
 								<Link
 									className="transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-									href={createSearchUrl({ tags: [id] })}
+									href={`/topics/${id}`}
 								>
 									{name}
 								</Link>

--- a/components/tags.tsx
+++ b/components/tags.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
 import { Link } from "#/components/link.tsx";
-import { createSearchUrl } from "#/lib/navigation/create-search-url.ts";
 
 interface TagsProps {
 	label: ReactNode;
@@ -27,7 +26,7 @@ export function Tags(props: Readonly<TagsProps>): ReactNode {
 							<li key={id} className="inline leading-none">
 								<Link
 									className="transition hover:text-brand-700 focus:outline-none focus-visible:ring focus-visible:ring-brand-700"
-									href={createSearchUrl({ tags: [id] })}
+									href={`/topics/${id}`}
 								>
 									{name}
 								</Link>

--- a/lib/content/client/people.ts
+++ b/lib/content/client/people.ts
@@ -1,14 +1,66 @@
-import { keyByToMap } from "@acdh-oeaw/lib";
+import { groupByToMap, keyByToMap, unique } from "@acdh-oeaw/lib";
+import curricula from "#content/curricula";
 import collection from "#content/people";
+import events from "#content/resources-events";
+import external from "#content/resources-external";
+import hosted from "#content/resources-hosted";
+import pathfinders from "#content/resources-pathfinders";
 
 import type { CollectionClient } from "#/lib/content/types";
+
+/** Not every collection has all of these fields, e.g. events only have authors. */
+function getPersonIds(metadata: {
+	authors?: Array<string>;
+	contributors?: Array<string>;
+	editors?: Array<string>;
+}): Array<string> {
+	const { authors = [], contributors = [], editors = [] } = metadata;
+
+	return unique([...authors, ...editors, ...contributors]);
+}
+
+const resourcesByPersonId = groupByToMap(
+	[
+		...Array.from(events.values()),
+		...Array.from(external.values()),
+		...Array.from(hosted.values()),
+		...Array.from(pathfinders.values()),
+	],
+	(entry) =>
+		getPersonIds(entry.document.metadata)
+	,
+);
+
+const curriculaByPersonId = groupByToMap(Array.from(curricula.values()), (entry) =>
+	getPersonIds(entry.document.metadata)
+);
+
+//
 
 const ids = Array.from(collection.keys());
 
 const all = Array.from(collection.values())
-	.map((entry) =>
-		entry.document
-	)
+	// oxlint-disable-next-line oxc/no-map-spread
+	.map((entry) => {
+		const href = `/people/${entry.document.id}`;
+
+		const resources =
+			resourcesByPersonId.get(entry.document.id)?.map((entry) =>
+				entry.document.id
+			) ?? [];
+
+		const curricula =
+			curriculaByPersonId.get(entry.document.id)?.map((entry) =>
+				entry.document.id
+			) ?? [];
+
+		return {
+			...entry.document,
+			href,
+			curricula,
+			resources,
+		};
+	})
 	// oxlint-disable-next-line unicorn/no-array-sort
 	.sort((a, z) =>
 		a.metadata.name.localeCompare(z.metadata.name)

--- a/lib/content/client/tags.ts
+++ b/lib/content/client/tags.ts
@@ -1,14 +1,55 @@
-import { keyByToMap } from "@acdh-oeaw/lib";
+import { groupByToMap, keyByToMap } from "@acdh-oeaw/lib";
+import curricula from "#content/curricula";
+import events from "#content/resources-events";
+import external from "#content/resources-external";
+import hosted from "#content/resources-hosted";
+import pathfinders from "#content/resources-pathfinders";
 import collection from "#content/tags";
 
 import type { CollectionClient } from "#/lib/content/types.ts";
 
+const resourcesByTagId = groupByToMap(
+	[
+		...Array.from(events.values()),
+		...Array.from(external.values()),
+		...Array.from(hosted.values()),
+		...Array.from(pathfinders.values()),
+	],
+	(entry) =>
+		entry.document.metadata.tags
+	,
+);
+
+const curriculaByTagId = groupByToMap(Array.from(curricula.values()), (entry) =>
+	entry.document.metadata.tags
+);
+
+//
+
 const ids = Array.from(collection.keys());
 
 const all = Array.from(collection.values())
-	.map((entry) =>
-		entry.document
-	)
+	// oxlint-disable-next-line oxc/no-map-spread
+	.map((entry) => {
+		const href = `/topics/${entry.document.id}`;
+
+		const resources =
+			resourcesByTagId.get(entry.document.id)?.map((entry) =>
+				entry.document.id
+			) ?? [];
+
+		const curricula =
+			curriculaByTagId.get(entry.document.id)?.map((entry) =>
+				entry.document.id
+			) ?? [];
+
+		return {
+			...entry.document,
+			href,
+			curricula,
+			resources,
+		};
+	})
 	// oxlint-disable-next-line unicorn/no-array-sort
 	.sort((a, z) =>
 		a.metadata.name.localeCompare(z.metadata.name)

--- a/lib/content/collections/people.ts
+++ b/lib/content/collections/people.ts
@@ -35,6 +35,8 @@ export const people = createCollection({
     return {
       id: item.id,
       content: module,
+      /** Most people don't have a biography, so pages need to know whether to render the content at all. */
+      hasContent: content.trim().length > 0,
       metadata: {
         ...metadata,
         image,

--- a/lib/content/github-client/index.ts
+++ b/lib/content/github-client/index.ts
@@ -279,12 +279,21 @@ export const createGitHubClient = cache(function createGitHubClient({
 
 			const { content, ...metadata } = data;
 
+			const href = `/people/${id}`;
 			const { default: component } = await evaluate(content, evaluateOptions);
 			const image = createGitHubUrl(metadata.image);
+
+			// TODO: read from prebuilt client?
+			const person = await client.collections.people.get(id);
+			const curricula = person?.curricula ?? [];
+			const resources = person?.resources ?? [];
 
 			return {
 				id,
 				content: component,
+				href,
+				curricula,
+				resources,
 				metadata: {
 					...metadata,
 					image,
@@ -613,11 +622,20 @@ export const createGitHubClient = cache(function createGitHubClient({
 
 			const { content, ...metadata } = data;
 
+			const href = `/topics/${id}`;
 			const { default: component } = await evaluate(content, evaluateOptions);
+
+			// TODO: read from prebuilt client?
+			const tag = await client.collections.tags.get(id);
+			const curricula = tag?.curricula ?? [];
+			const resources = tag?.resources ?? [];
 
 			return {
 				id,
 				content: component,
+				href,
+				curricula,
+				resources,
 				metadata,
 			};
 		},

--- a/lib/content/github-client/index.ts
+++ b/lib/content/github-client/index.ts
@@ -282,6 +282,7 @@ export const createGitHubClient = cache(function createGitHubClient({
 			const href = `/people/${id}`;
 			const { default: component } = await evaluate(content, evaluateOptions);
 			const image = createGitHubUrl(metadata.image);
+			const hasContent = content.trim().length > 0;
 
 			// TODO: read from prebuilt client?
 			const person = await client.collections.people.get(id);
@@ -291,6 +292,7 @@ export const createGitHubClient = cache(function createGitHubClient({
 			return {
 				id,
 				content: component,
+				hasContent,
 				href,
 				curricula,
 				resources,

--- a/messages/en.json
+++ b/messages/en.json
@@ -304,6 +304,12 @@
 		},
 		"title": "Pathfinders"
 	},
+	"PersonPage": {
+		"authors": "Authors",
+		"curricula": "Curricula",
+		"editors": "Editors",
+		"resources": "Resources"
+	},
 	"PublicationDate": {
 		"label": "Published to DARIAH-Campus"
 	},
@@ -399,5 +405,11 @@
 		},
 		"resources": "{count, plural, =0 {no resources} =1 {one resource} other {# resources}}",
 		"title": "Sources"
+	},
+	"TopicPage": {
+		"authors": "Authors",
+		"curricula": "Curricula",
+		"editors": "Editors",
+		"resources": "Resources"
 	}
 }


### PR DESCRIPTION
add dedicated details pages for people and topics, and point links to those pages instead of pre-selected filters on search page.